### PR TITLE
chore: updated task to setup an EKS cluster under the name nuvolaris-eks

### DIFF
--- a/clusters/eks-cluster.yml
+++ b/clusters/eks-cluster.yml
@@ -19,8 +19,8 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
-  name: nuvolaris-cluster
-  region: us-west-1
+  name: nuvolaris-eks
+  region: us-east-1
 
 iam:
   withOIDC: true
@@ -28,7 +28,7 @@ iam:
 nodeGroups:
   - name: ng-1
     instanceType: m5.xlarge
-    desiredCapacity: 1
+    desiredCapacity: 2
     volumeSize: 80
     ssh:
       publicKeyPath: id_rsa.pub

--- a/clusters/eks.yml
+++ b/clusters/eks.yml
@@ -25,18 +25,18 @@ tasks:
   destroy:
     - eksctl delete cluster -f eks-cluster.yml
   
-  #--name nuvolaris-cluster --region=eu-central-1
+  #--name nuvolaris-cluster --region=us-east-1
 
-  list: eksctl get cluster
+  list: eksctl get cluster --region=us-east-1
 
   config: |-
-    aws eks update-kubeconfig --kubeconfig eks.kubeconfig --name=nuvolaris-cluster
+    aws eks update-kubeconfig --kubeconfig eks.kubeconfig --name=nuvolaris-eks --region=us-east-1
     cp eks.kubeconfig ~/.kube/config
-    kubectl get nodes
+    kubectl get nodes 
 
-  avail-addons: eksctl utils describe-addon-versions --cluster=nuvolaris-cluster
+  avail-addons: eksctl utils describe-addon-versions --cluster=nuvolaris-eks --region=us-east-1
 
-  list-addon: eksctl get addons --cluster=nuvolaris-cluster
+  list-addon: eksctl get addons --cluster=nuvolaris-eks --region=us-east-1
 
   reset:
     - kubectl delete -f ../deploy/cert-manager/cert-manager.yaml


### PR DESCRIPTION
Changed the eke cluster setup to create a nuvolaris-eks cluster in AWS region eu-east-1. After task eke:create is completed ingress and cert-manager can be added by executing task eks:setup