### PR TITLE
[MONGODB-STANDALONE]: FIX for probe failures causing restarting

### DIFF
--- a/deploy/mongodb-standalone/mongodb-sts.yaml
+++ b/deploy/mongodb-standalone/mongodb-sts.yaml
@@ -34,13 +34,14 @@ spec:
         app: nuvolaris-mongodb
     spec:
       containers:
-      - image: mongo
+      - image: mongo:5.0.11
         name: mongodb
         args: ["--dbpath","/data/db", "--bind_ip", "0.0.0.0"]
         livenessProbe:
           exec:
             command:
-              - mongosh
+              - mongo
+              - --disableImplicitSessions
               - --eval
               - "db.adminCommand('ping')"
           initialDelaySeconds: 30
@@ -51,7 +52,8 @@ spec:
         readinessProbe:
           exec:
             command:
-              - mongosh
+              - mongo
+              - --disableImplicitSessions
               - --eval
               - "db.adminCommand('ping')"
           initialDelaySeconds: 30

--- a/nuvolaris/templates/mongodb-sts.yaml
+++ b/nuvolaris/templates/mongodb-sts.yaml
@@ -35,16 +35,17 @@ spec:
         nuvolaris.mongodb.flavour: standalone
     spec:
       containers:
-      - image: mongo
+      - image: mongo:5.0.11
         name: mongodb
         args: ["--dbpath","/data/db", "--bind_ip", "0.0.0.0"]
         livenessProbe:
           exec:
             command:
-              - mongosh
+              - mongo
+              - --disableImplicitSessions
               - --eval
               - "db.adminCommand('ping')"
-          initialDelaySeconds: 60
+          initialDelaySeconds: 40
           periodSeconds: 10
           timeoutSeconds: 10
           successThreshold: 1
@@ -52,7 +53,8 @@ spec:
         readinessProbe:
           exec:
             command:
-              - mongosh
+              - mongo
+              - --disableImplicitSessions
               - --eval
               - "db.adminCommand('ping')"
           initialDelaySeconds: 20


### PR DESCRIPTION
Mongodb standalone deployer was using the latest version of mongodb 5 using mongosh  based readiness and liveness probe. it looks like mongosh suffer performance issues which ere causing continuous restart due to liveness probe failure. 

This patch uses mongodb 5.0.11 and uses mongo based probes and issues seems to be solved now. 

There are quite a lot of issues regarding mongosh performance/memory problems as for instance https://jira.mongodb.org/browse/MONGOSH-1240?jql=text%20~%20%22mongosh%22

To update nuvolaris standalone mongodb deployer it is necessary to take into account wether mongo shell it is still supported or not.