### PR TITLE
fix: improved minio pod readiness check and adapted corresponding test

### DIFF
--- a/deploy/nuvolaris-permissions/openwhisk-runtimes-cm.yaml
+++ b/deploy/nuvolaris-permissions/openwhisk-runtimes-cm.yaml
@@ -53,7 +53,7 @@ data:
                 },
                 "stemCells": [
                     {
-                        "initialCount": 2,
+                        "initialCount": 1,
                         "memory": "256 MB",
                         "reactive": {
                             "minCount": 1,
@@ -82,7 +82,7 @@ data:
                 },
                 "stemCells": [
                     {
-                        "initialCount": 2,
+                        "initialCount": 1,
                         "memory": "256 MB",
                         "reactive": {
                             "minCount": 1,
@@ -93,7 +93,21 @@ data:
                         }
                     }
                 ]
-            }
+            },
+            {
+                "kind": "python:310ai",
+                "default": false,
+                "image": {
+                    "prefix": "ghcr.io/nuvolaris",
+                    "name": "action-python-v310-ai",
+                    "tag": "0.3.0-morpheus.23030312"
+                },
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
+            }            
         ],
         "java": [
             {

--- a/nuvolaris/templates/standalone-sts.yaml
+++ b/nuvolaris/templates/standalone-sts.yaml
@@ -83,7 +83,7 @@ spec:
 
         # Java options
         - name: "JAVA_OPTS"
-          value: "-Xmx1024M "
+          value: "-Xmx2048M "
 
         # specific controller arguments
         - name: "CONTROLLER_OPTS"

--- a/tests/api.js
+++ b/tests/api.js
@@ -20,7 +20,8 @@
 const openwhisk = require('openwhisk');
 
 function main(args) {
-    var ow = openwhisk();
+    var options = {apihost: 'http://controller:3233'};
+    var ow = openwhisk(options);
     //return { "body": "boh"}
     return ow.actions.list()
     .then(l => ({body: {result: l}}))

--- a/tests/kind/minio_test.ipy
+++ b/tests/kind/minio_test.ipy
@@ -24,6 +24,7 @@ import nuvolaris.kube as kube
 import nuvolaris.minio as minio
 import nuvolaris.couchdb as cdb
 import nuvolaris.couchdb_util as cdbu
+import nuvolaris.util as util
 import logging
 
 # test
@@ -31,7 +32,7 @@ assert(cfg.configure(tu.load_sample_config()))
 assert(cfg.detect_storage()["nuvolaris.storageClass"])
 assert(minio.create())
 
-pod_name = minio.get_minio_standalone_pod_name()
+pod_name = util.get_pod_name("{.items[?(@.metadata.labels.app == 'minio')].metadata.name}")
 assert(pod_name)
 
 actual_minio_root_user = kube.kubectl("get", f"pods/{pod_name}", jsonpath="{.spec.containers[0].env[0].value}")

--- a/tests/kind/wskadmin.ipy
+++ b/tests/kind/wskadmin.ipy
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all
+
 !kubectl -n nuvolaris apply -f deploy/couchdb
 !cat tests/kind/whisk.yaml | sed -e 's/host: couchdb/host: localhost/' | kubectl apply -f -
 
@@ -22,6 +25,7 @@ import nuvolaris.couchdb as cdb
 import nuvolaris.couchdb_util as cu
 import nuvolaris.testutil as tu
 import nuvolaris.config as cfg
+import nuvolaris.kube as kube
 
 scf = tu.load_sample_config()
 assert(cfg.configure(scf))

--- a/wskadmin.sh
+++ b/wskadmin.sh
@@ -21,7 +21,7 @@ configure() {
     if test -e whisk.properties
     then return
     fi
-    if ! kubectl get wsk/controller 2>/dev/null >/dev/null
+    if ! kubectl -n nuvolaris get wsk/controller 2>/dev/null >/dev/null
     then 
         echo "Nuvolaris not yet configured"
         exit 1


### PR DESCRIPTION
Includes:
- Improvements on MINIO deployment component
- Updates runtimes.json to avoid spawing too many runtimes at startup that could be un-necessary for the standalone
- Update standalone JVM memory request to 2GB as sometimes it refuses to execute the task all actions