### PR TITLE
Improves nuvolaris/nuvolaris#146

### DIFF
--- a/nuvolaris/config.py
+++ b/nuvolaris/config.py
@@ -16,6 +16,7 @@
 # under the License.
 #
 import flatdict, json, os
+import logging
 
 _config = {}
 
@@ -134,3 +135,8 @@ def detect():
     detect_storage()
     detect_labels()
     detect_env()
+
+def dump_config():
+    import nuvolaris.config as cfg
+    for k in cfg.getall():
+        logging.debug(f"{k} = {cfg.get(k)}") 

--- a/nuvolaris/kube.py
+++ b/nuvolaris/kube.py
@@ -163,4 +163,11 @@ def scale_sts(name, replicas, namespace="nuvolaris"):
     try:
         return kubectl("scale", name, f"--replicas={replicas}" ,namespace=namespace)
     except:
-        return None      
+        return None
+
+# rollout the specified element. Normally used for DeamonSet or StatefulSet
+def rollout(name, namespace="nuvolaris"):
+    try:
+        return kubectl("rollout", "restart", name, namespace=namespace)
+    except:
+        return None            

--- a/nuvolaris/main.py
+++ b/nuvolaris/main.py
@@ -259,7 +259,7 @@ def whisk_update(spec, status, namespace, diff, name, **kwargs):
         patcher.redeploy_whisk(owner)
 
 @kopf.on.resume('nuvolaris.org', 'v1', 'whisks')
-def whisk_create(spec, name, **kwargs):
+def whisk_resume(spec, name, **kwargs):
     logging.info(f"*** whisk_resume {name}")
 
     cfg.clean()

--- a/nuvolaris/main.py
+++ b/nuvolaris/main.py
@@ -49,7 +49,7 @@ def whisk_create(spec, name, **kwargs):
     cfg.clean()
     cfg.configure(spec)
     cfg.detect()
-    for k in cfg.getall(): logging.debug(f"{k} = {cfg.get(k)}")
+    cfg.dump_config()
     owner = kube.get(f"wsk/{name}")
 
     state = {
@@ -252,7 +252,7 @@ def whisk_update(spec, status, namespace, diff, name, **kwargs):
     cfg.detect()
 
     logging.debug("*** dumping new configuration parameters")
-    for k in cfg.getall(): logging.debug(f"{k} = {cfg.get(k)}")
+    cfg.dump_config()
     owner = kube.get(f"wsk/{name}")
 
     if cfg.get('components.openwhisk'):
@@ -267,7 +267,7 @@ def whisk_resume(spec, name, **kwargs):
     cfg.detect()
 
     logging.debug("*** dumping resumed configuration parameters")
-    for k in cfg.getall(): logging.debug(f"{k} = {cfg.get(k)}")          
+    cfg.dump_config()          
 
 def runtimes_filter(name, type, **kwargs):
     return name == 'openwhisk-runtimes' and type == 'MODIFIED'  

--- a/nuvolaris/main.py
+++ b/nuvolaris/main.py
@@ -256,7 +256,18 @@ def whisk_update(spec, status, namespace, diff, name, **kwargs):
     owner = kube.get(f"wsk/{name}")
 
     if cfg.get('components.openwhisk'):
-        patcher.redeploy_whisk(owner)    
+        patcher.redeploy_whisk(owner)
+
+@kopf.on.resume('nuvolaris.org', 'v1', 'whisks')
+def whisk_create(spec, name, **kwargs):
+    logging.info(f"*** whisk_resume {name}")
+
+    cfg.clean()
+    cfg.configure(spec)
+    cfg.detect()
+
+    logging.debug("*** dumping resumed configuration parameters")
+    for k in cfg.getall(): logging.debug(f"{k} = {cfg.get(k)}")          
 
 def runtimes_filter(name, type, **kwargs):
     return name == 'openwhisk-runtimes' and type == 'MODIFIED'  
@@ -265,5 +276,6 @@ def runtimes_filter(name, type, **kwargs):
 def runtimes_cm_event_watcher(event, **kwargs):    
     logging.info("*** deteched a change in cm/openwhisk-runtimes config map, restarting openwhisk related PODs")
     owner = kube.get(f"wsk/controller")
+
     if cfg.get('components.openwhisk'):
         patcher.restart_whisk(owner)

--- a/nuvolaris/openwhisk_patcher.py
+++ b/nuvolaris/openwhisk_patcher.py
@@ -21,6 +21,14 @@ import nuvolaris.config as cfg
 import nuvolaris.kube as kube
 import nuvolaris.util as util
 
+def rollout(kube_name):
+    try:
+        logging.info(f"*** handling request to rollout {kube_name}")
+        kube.rollout(kube_name)
+        logging.info(f"*** handled request to rollout {kube_name}")
+    except Exception as e:
+        logging.error('*** failed to rollout %s: %s' % kube_name,e)
+
 def restart_sts(sts_name):
     try:
         logging.info(f"*** handling request to redeploy {sts_name} using scaledown/scaleup")
@@ -40,17 +48,15 @@ def restart_sts(sts_name):
 def redeploy_controller(owner=None):
     try:
         logging.info("*** handling request to redeploy whisk controller")      
-        msg = openwhisk.delete()
-        logging.info(msg)
-
         msg = openwhisk.create(owner)
         logging.info(msg)
+        rollout("sts/controller")
         logging.info("*** handled request to redeploy whisk controller") 
     except Exception as e:
         logging.error('*** failed to redeploy whisk controller: %s' % e) 
 
 def restart_whisk(owner=None):
-    restart_sts("sts/controller")
+    rollout("sts/controller")
 
 def redeploy_whisk(owner=None):
     redeploy_controller(owner)

--- a/nuvolaris/openwhisk_standalone.py
+++ b/nuvolaris/openwhisk_standalone.py
@@ -36,9 +36,11 @@ def create(owner=None):
     config += kus.patchTemplates("openwhisk-standalone", ["standalone-sts.yaml"], data) 
     spec = kus.kustom_list("openwhisk-standalone", config, templates=[], data=data)
 
-    cfg.put(CONTROLLER_SPEC, spec)
     if owner:
         kopf.append_owner_reference(spec['items'], owner)
+    else:
+        cfg.put(CONTROLLER_SPEC, spec)
+
     
     res = kube.apply(spec)
 

--- a/nuvolaris/openwhisk_standalone.py
+++ b/nuvolaris/openwhisk_standalone.py
@@ -36,11 +36,9 @@ def create(owner=None):
     config += kus.patchTemplates("openwhisk-standalone", ["standalone-sts.yaml"], data) 
     spec = kus.kustom_list("openwhisk-standalone", config, templates=[], data=data)
 
+    cfg.put(CONTROLLER_SPEC, spec)
     if owner:
         kopf.append_owner_reference(spec['items'], owner)
-        cfg.put(CONTROLLER_SPEC, spec)
-    else:
-        cfg.put(CONTROLLER_SPEC, spec)
     
     res = kube.apply(spec)
 
@@ -55,4 +53,4 @@ def delete():
     if cfg.exists(CONTROLLER_SPEC):
         res = kube.delete(cfg.get(CONTROLLER_SPEC))
         cfg.delete(CONTROLLER_SPEC)
-    res += kube.kubectl("delete", "pod", "-l", "user-action-pod=true")        
+    res += kube.kubectl("delete", "pod", "-l", "user-action-pod=true")       

--- a/nuvolaris/openwhisk_standalone.py
+++ b/nuvolaris/openwhisk_standalone.py
@@ -38,6 +38,7 @@ def create(owner=None):
 
     if owner:
         kopf.append_owner_reference(spec['items'], owner)
+        cfg.put(CONTROLLER_SPEC, spec)
     else:
         cfg.put(CONTROLLER_SPEC, spec)
     

--- a/tests/patcher/whisk-update.yaml
+++ b/tests/patcher/whisk-update.yaml
@@ -97,4 +97,4 @@ spec:
       triggers: 
         fires-perMinute: 999
     controller:
-      javaOpts: "-Xmx4096M"        
+      javaOpts: "-Xmx2048M"        


### PR DESCRIPTION
Uses kubectl rollout to perform a clean restart of OpenWhisk controller when a change to runtimes or whisk file is detected.