### PR TITLE
Implements nuvolaris/nuvolaris#148

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -167,6 +167,8 @@ tasks:
 
   clean:
     cmds:
+      - cmd: kubectl -n nuvolaris delete wsku --all
+        ignore_error: true    
       - cmd: kubectl -n nuvolaris delete wsk/controller
         ignore_error: true
       - cmd: kubectl -n nuvolaris delete all --all

--- a/TaskfileDev.yml
+++ b/TaskfileDev.yml
@@ -50,6 +50,7 @@ tasks:
       CONTROLLER_IMAGE: "{{.CONTROLLER_IMAGE}}"
       CONTROLLER_TAG: "{{.CONTROLLER_TAG}}"
       OPERATOR_TAG: "{{.OPERATOR_TAG}}"
+      COUCHDB_SERVICE_HOST: "localhost"
 
   instance:
     -  envsubst <{{.CONFIG}} | kubectl -n nuvolaris apply -f -

--- a/deploy/nuvolaris-permissions/operator-roles.yaml
+++ b/deploy/nuvolaris-permissions/operator-roles.yaml
@@ -49,9 +49,9 @@ rules:
   resources: ["jobs", "cronjobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
-# edit nuvolaris crd
+# edit nuvolaris crds
 - apiGroups: ["nuvolaris.org"]
-  resources: ["whisks","whisks/status"]
+  resources: ["whisks","whisks/status","whisksusers","whisksusers/status"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 # networking.k8s.io

--- a/deploy/nuvolaris-permissions/whisk-user-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-user-crd.yaml
@@ -16,20 +16,38 @@
 # under the License.
 #
 ---
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: whisks-users.nuvolaris.org
+  name: whisksusers.nuvolaris.org
   namespace: nuvolaris
 spec:
   scope: Namespaced
   group: nuvolaris.org
   names:
     kind: WhiskUser
-    plural: whisksUsers
+    plural: whisksusers
     singular: whiskuser
     shortNames:
-      - wsk.user
+      - wsku
   versions:
     - name: v1
       served: true
@@ -49,10 +67,6 @@ spec:
                   type: string
                 namespace:
                   type: string
-              required:
-                - email
-                - password
-                - namespace
                 redis:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -95,6 +109,10 @@ spec:
                       type: string
                     password:
                       type: string
+              required:
+                - email
+                - password
+                - namespace 
             status:
               x-kubernetes-preserve-unknown-fields: true
               # type: object

--- a/deploy/nuvolaris-user/whisk-user-crd.yaml
+++ b/deploy/nuvolaris-user/whisk-user-crd.yaml
@@ -1,0 +1,140 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: whisks-users.nuvolaris.org
+  namespace: nuvolaris
+spec:
+  scope: Namespaced
+  group: nuvolaris.org
+  names:
+    kind: WhiskUser
+    plural: whisksUsers
+    singular: whiskuser
+    shortNames:
+      - wsk.user
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources: { status: { } } 
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+                namespace:
+                  type: string
+              required:
+                - email
+                - password
+                - namespace
+                redis:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    enabled:
+                      type: boolean
+                    prefix:
+                      type: string
+                    password:
+                      type: string
+                object-storage:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    enabled:
+                      type: boolean
+                    bucket:
+                      type: string
+                    password:
+                      type: string
+                mongodb:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    enabled:
+                      type: boolean
+                    database:
+                      type: string
+                    password:
+                      type: string
+                route:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    enabled:
+                      type: boolean
+                    host:
+                      type: string
+                    bucket:
+                      type: string
+                    password:
+                      type: string
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+              # type: object
+              # properties:
+              #   wsk_user_create:
+              #     type: object
+              #     properties:
+              #       couchdb:
+              #         type: string
+              #       mongodb:
+              #         type: string
+              #       redis:
+              #         type: string
+              #       object-storage:
+              #         type: string
+              #       route:
+              #         type: string                            
+      additionalPrinterColumns:
+        - name: CouchDB
+          type: string
+          priority: 0
+          jsonPath: .status.whisk_user_create.couchdb
+          description: CouchDB
+        - name: MongoDB
+          type: string
+          priority: 0
+          jsonPath: .status.whisk_user_create.mongodb
+          description: MongoDB
+        - name: Redis
+          type: string
+          priority: 0
+          jsonPath: .status.whisk_user_create.redis
+          description: Redis
+        - name: ObjectStorage
+          type: string
+          priority: 0
+          jsonPath: .status.whisk_user_create.s3bucket
+          description: ObjectStorage
+        - name: Route
+          type: string
+          priority: 0
+          jsonPath: .status.whisk_user_create.minio
+          description: Route                              

--- a/nuvolaris/config.py
+++ b/nuvolaris/config.py
@@ -39,12 +39,13 @@ def exists(key):
 
 def get(key, envvar=None, defval=None):
     val = _config.get(key)
-    if val: 
-        return val
+
     if envvar and envvar in os.environ:
         val = os.environ[envvar]
+    
     if val: 
         return val
+    
     return defval
 
 def put(key, value):

--- a/nuvolaris/couchdb.py
+++ b/nuvolaris/couchdb.py
@@ -192,7 +192,7 @@ def create_ow_user(subject, auth):
         else:
             return None
     except Exception as e:
-        logging.error('failed to authorize Openwhisk namespace %s authorization id and key: %s' % subject, e)
+        logging.error(f"failed to authorize Openwhisk namespace {subject} authorization id and key: {e}")
         return None
 
 def delete_ow_user(subject):
@@ -213,7 +213,7 @@ def delete_ow_user(subject):
         logging.warn(f"auhorization for OpenWhisk namespace {subject} not found!")
         return None
     except Exception as e:
-        logging.error('failed to remove Openwhisk namespace %s authorization id and key: %s' % subject, e)
+        logging.error(f"failed to remove Openwhisk namespace {subject} authorization id and key: {e}")
         return None
 
 

--- a/nuvolaris/testutil.py
+++ b/nuvolaris/testutil.py
@@ -252,4 +252,9 @@ def generate_ow_auth():
     """     
     uid = generate_ow_uid()
     key = generate_ow_key()
-    return f"{uid}:{key}"    
+    return f"{uid}:{key}"
+
+def load_sample_user_config(name="whisk-user"):
+    with open(f"tests/{name}.yaml") as f: 
+        c = yaml.safe_load(f)
+        return c['spec']    

--- a/nuvolaris/testutil.py
+++ b/nuvolaris/testutil.py
@@ -21,6 +21,9 @@ import flatdict
 import json
 import time
 import requests as req
+import uuid
+import string
+import random
 
 # takes a string, split in lines and search for the word (a re)
 # if field is a number, splits the line in fields separated by spaces and print the selected field
@@ -224,3 +227,29 @@ def retry(fn, value, max=10, delay=1):
         time.sleep(delay)
         print(i, "retrying...")
     return False
+
+def generate_ow_uid():
+    """
+        >>> import nuvolaris.testutil as util        
+        >>> len(util.generate_ow_uid())
+        36
+    """ 
+    return str(uuid.uuid4())
+
+def generate_ow_key():
+    """
+        >>> import nuvolaris.testutil as util        
+        >>> len(util.generate_ow_key())
+        64
+    """ 
+    return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(64))
+
+def generate_ow_auth():
+    """
+        >>> import nuvolaris.testutil as util        
+        >>> len(util.generate_ow_auth())
+        101
+    """     
+    uid = generate_ow_uid()
+    key = generate_ow_key()
+    return f"{uid}:{key}"    

--- a/nuvolaris/user_config.py
+++ b/nuvolaris/user_config.py
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import flatdict, json, os
+import logging
+
+class UserConfig:
+    _config = {}
+
+    def __init__(self, spec):
+        self.configure(spec)
+        pass
+
+    # define a configuration 
+    # the configuration is a map, followed by a list of labels 
+    # the map can be a serialized json and will be flattened to a map of values.
+    # you can have only a configuration active at a time
+    # if you want to set a new configuration you have to clean it
+    def configure(self,spec: dict):
+        self._config = dict(flatdict.FlatDict(spec, delimiter="."))
+        return True
+
+    def clean(self):    
+        self._config = {}
+
+    def exists(self,key):
+        return key in self._config
+
+    def get(self,key, envvar=None, defval=None):
+        val = self._config.get(key)
+
+        if envvar and envvar in os.environ:
+            val = os.environ[envvar]
+        
+        if val: 
+            return val
+        
+        return defval
+
+    def put(self,key, value):
+        self._config[key] = value
+        return True
+
+    def delete(self, key):
+        if key in self._config:
+            del self._config[key]
+            return True
+
+    def getall(self,prefix=""):
+        res = {}
+        for key in self._config.keys():
+            if key.startswith(prefix):
+                res[key] = self._config[key]
+        return res
+
+    def keys(self, prefix=""):
+        res = []
+        if self._config:
+            for key in self._config.keys():
+                if key.startswith(prefix):
+                    res.append(key)
+        return res
+
+    def dump_config(self):
+        for k in self.getall():
+            logging.debug(f"{k} = {self._config.get(k)}")
+

--- a/nuvolaris/user_handlers.py
+++ b/nuvolaris/user_handlers.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Provides extra kopf handlers to manage nuvolaris users
+import kopf
+import logging
+import json, flatdict, os, os.path
+import nuvolaris.config as cfg
+import nuvolaris.couchdb as cdb
+
+@kopf.on.create('nuvolaris.org', 'v1', 'whisksusers')
+def whisk_user_create(spec, name, **kwargs):
+    logging.info(f"*** whisk_user_create {name}")
+    state = {
+    }
+
+    if(spec['namespace'] and spec['password']):
+        res = cdb.create_ow_user(spec['namespace'],spec['password'])
+        logging.info(f"OpenWhisk subject {spec['namespace']} added = {res}")
+        state['couchdb']= res
+
+    return state
+
+@kopf.on.delete('nuvolaris.org', 'v1', 'whisksusers')
+def whisk_user_delete(spec, name, **kwargs):
+    logging.info(f"*** whisk_user_delete {name}")
+
+    if(spec['namespace']):
+        res = cdb.delete_ow_user(spec['namespace'])
+        logging.info(f"OpenWhisk subject {spec['namespace']} removed = {res}")
+
+@kopf.on.update('nuvolaris.org', 'v1', 'whisksusers')
+def whisk_user_update(spec, status, namespace, diff, name, **kwargs):
+    logging.info(f"*** detected an update of wsku/{name} under namespace {namespace}")

--- a/nuvolaris/user_handlers.py
+++ b/nuvolaris/user_handlers.py
@@ -21,6 +21,12 @@ import logging
 import json, flatdict, os, os.path
 import nuvolaris.config as cfg
 import nuvolaris.couchdb as cdb
+import nuvolaris.user_config as user_config
+
+def get_ucfg(spec):
+    ucfg = user_config.UserConfig(spec)
+    ucfg.dump_config()
+    return ucfg
 
 @kopf.on.create('nuvolaris.org', 'v1', 'whisksusers')
 def whisk_user_create(spec, name, **kwargs):
@@ -28,9 +34,11 @@ def whisk_user_create(spec, name, **kwargs):
     state = {
     }
 
-    if(spec['namespace'] and spec['password']):
-        res = cdb.create_ow_user(spec['namespace'],spec['password'])
-        logging.info(f"OpenWhisk subject {spec['namespace']} added = {res}")
+    ucfg = get_ucfg(spec)
+
+    if(ucfg.get("namespace") and ucfg.get("password")):
+        res = cdb.create_ow_user(ucfg.get("namespace"),ucfg.get("password"))
+        logging.info(f"OpenWhisk subject {ucfg.get('namespace')} added = {res}")
         state['couchdb']= res
 
     return state
@@ -39,9 +47,11 @@ def whisk_user_create(spec, name, **kwargs):
 def whisk_user_delete(spec, name, **kwargs):
     logging.info(f"*** whisk_user_delete {name}")
 
-    if(spec['namespace']):
-        res = cdb.delete_ow_user(spec['namespace'])
-        logging.info(f"OpenWhisk subject {spec['namespace']} removed = {res}")
+    ucfg = get_ucfg(spec)
+
+    if(ucfg.get("namespace")):
+        res = cdb.delete_ow_user(ucfg.get("namespace"))
+        logging.info(f"OpenWhisk subject {ucfg.get('namespace')} removed = {res}")
 
 @kopf.on.update('nuvolaris.org', 'v1', 'whisksusers')
 def whisk_user_update(spec, status, namespace, diff, name, **kwargs):

--- a/tests/kind/config_user_test.ipy
+++ b/tests/kind/config_user_test.ipy
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import nuvolaris.user_config as user_cfg
+import nuvolaris.testutil as tu
+
+spec = tu.load_sample_user_config()
+cfg = user_cfg.UserConfig(spec)
+
+assert(cfg.get("namespace") == "ftt")

--- a/tests/kind/nuvolaris_subject_test.ipy
+++ b/tests/kind/nuvolaris_subject_test.ipy
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all
+
+import nuvolaris.couchdb as cdb
+import nuvolaris.couchdb_util as cdbu
+import nuvolaris.testutil as tu
+import nuvolaris.config as cfg
+import nuvolaris.kube as kube
+import requests as req
+import time
+import subprocess
+import json
+from kopf.testing import KopfRunner
+
+assert(cfg.configure(tu.load_sample_config()))
+assert(cfg.detect_labels()["nuvolaris.kube"] == "kind")
+assert(cfg.detect_storage()["nuvolaris.storageClass"] == "standard")
+assert(cfg.put("couchdb.host", "localhost"))
+
+!kubectl apply -f tests/kind/whisk.yaml
+wsk = kube.get("wsk/controller")
+cdb.create(wsk)
+
+import nuvolaris.couchdb_util
+db = nuvolaris.couchdb_util.CouchDB()
+
+assert(db.wait_db_ready(60))
+assert(db.configure_single_node())
+assert(db.configure_no_reduce_limit())
+
+assert(cdb.init_system(db))
+assert(cdb.init_subjects(db))
+assert(cdb.init_activations(db))
+assert(cdb.init_actions(db))
+assert(cdb.add_initial_subjects(db))
+
+with KopfRunner(['run', '-A', '--verbose', 'nuvolaris/user_handlers.py']) as runner:
+    # do something while the operator is running.
+    !kubectl apply -f tests/whisk-user.yaml      
+    time.sleep(1)  # give it some time to react and to sleep and to retry
+    wsku = kube.get("wsku/ftt")    
+    assert(wsku['spec'])
+
+    !kubectl delete -f tests/whisk-user.yaml           
+    time.sleep(1)  # give it some time to react
+
+assert runner.exit_code == 0
+assert runner.exception is None
+
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all
+

--- a/tests/kind/whisk-user.yaml
+++ b/tests/kind/whisk-user.yaml
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,8 +15,29 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-echo CONTROLLER: "$CONTROLLER_IMAGE:$CONTROLLER_TAG"
-echo OPERATOR: "$OPERATOR_IMAGE:$OPERATOR_TAG"
-
-kubectl apply -f deploy/nuvolaris-permissions/
-poetry run kopf run -n nuvolaris -m nuvolaris nuvolaris/main.py nuvolaris/user_handlers.py "$@"
+apiVersion: nuvolaris.org/v1
+kind: WhiskUser
+metadata:
+  name: franztt
+  namespace: nuvolaris
+spec: 
+  email: francesco@nuvolaris.io
+  password: 51b64cd0-d765-419e-990d-d7dd30d7b68f:vPtIjR2MFMlYY7U5BY6N7TTogZXnJa8cl6ygPGnJIXOJonfA6MuNpVAdLN7m8iVc
+  namespace: franztt
+  redis:
+    enabled: true
+    prefix: ftt
+    password: fttredispwd
+  object-storage:
+    enabled: true
+    bucket: ftt-data
+    password: dsadgasdfsagdfasfda
+  mongodb:
+    enabled: true
+    database: ftt
+    password: ahfdajsfdafdasffdasdja
+  route:
+    enabled: true
+    host: localhost
+    bucket: ftt-web
+    password: sadgsagdsagdsagdsagdakajg

--- a/tests/whisk-user.yaml
+++ b/tests/whisk-user.yaml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: nuvolaris.org/v1
+kind: WhiskUser
+metadata:
+  name: ftt
+  namespace: nuvolaris
+spec: 
+  email: francesco@nuvolaris.io
+  password: 51b64cd0-d765-419e-990d-d7dd30d7b68f:vPtIjR2MFMlYY7U5BY6N7TTogZXnJa8cl6ygPGnJIXOJonfA6MuNpVAdLN7m8iVc
+  namespace: ftt
+  redis:
+    enabled: false
+    prefix: ftt
+    password: fttredispwd
+  object-storage:
+    enabled: false
+    bucket: ftt-data
+    password: dsadgasdfsagdfasfda
+  mongodb:
+    enabled: false
+    database: ftt
+    password: ahfdajsfdafdasffdasdja
+  route:
+    enabled: false
+    host: localhost
+    bucket: ftt-web
+    password: sadgsagdsagdsagdsagdakajg


### PR DESCRIPTION
This PR introduces

- a new whisk-user CRD to be used to customise a new OW namespace, a dedicated mongodb db, a dedicated redis db, dedicated minio buckets and hostname to expose static content
- handles the creation/removal of an OW subject authorised to operate on a specific OW namespace