### PR TITLE
Implements nuvolaris/nuvolaris#148, nuvolaris/nuvolaris#149, nuvolaris/nuvolaris#150, nuvolaris/nuvolaris#151, nuvolaris/nuvolaris#152

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,8 @@ ADD deploy/cert-manager /home/nuvolaris/deploy/cert-manager
 ADD deploy/ingress-nginx /home/nuvolaris/deploy/ingress-nginx
 ADD deploy/issuer /home/nuvolaris/deploy/issuer
 ADD deploy/minio /home/nuvolaris/deploy/minio
+ADD deploy/nginx-static /home/nuvolaris/deploy/nginx-static
+ADD deploy/content /home/nuvolaris/deploy/content
 ADD run.sh dbinit.sh cron.sh pyproject.toml poetry.lock /home/nuvolaris/
 RUN chown -R nuvolaris:nuvolaris /home/nuvolaris
 USER nuvolaris

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,16 @@ RUN WSK_VERSION=1.2.0 ;\
     ARCH=$(dpkg --print-architecture) ;\
     WSK_URL="$WSK_BASE/$WSK_VERSION/OpenWhisk_CLI-$WSK_VERSION-linux-$ARCH.tgz" ;\
     curl -sL "$WSK_URL" | tar xzvf - -C /usr/bin/
+# Download MINIO client
+RUN rm -Rvf /tmp/minio-binaries ;\
+    mkdir /tmp/minio-binaries ;\
+    MINIO_BASE=https://dl.min.io/client/mc/release/linux ;\
+    ARCH=$(dpkg --print-architecture) ;\
+    MINIO_URL="$MINIO_BASE-$ARCH/mc" ;\
+    curl -sL "$MINIO_URL" --create-dirs -o /tmp/minio-binaries/mc ;\
+    chmod +x /tmp/minio-binaries/mc ;\
+    mv /tmp/minio-binaries/mc /usr/bin/mc ;\
+    rm -Rvf /tmp/minio-binaries
 # add user
 RUN useradd -m -s /bin/bash nuvolaris && \
     echo "nuvolaris ALL=(ALL:ALL) NOPASSWD: ALL" >>/etc/sudoers
@@ -53,6 +63,7 @@ WORKDIR /home/nuvolaris
 ADD nuvolaris/*.py /home/nuvolaris/nuvolaris/
 ADD nuvolaris/files /home/nuvolaris/nuvolaris/files
 ADD nuvolaris/templates /home/nuvolaris/nuvolaris/templates
+ADD nuvolaris/policies /home/nuvolaris/nuvolaris/policies
 ADD deploy/nuvolaris-operator /home/nuvolaris/deploy/nuvolaris-operator
 ADD deploy/nuvolaris-permissions /home/nuvolaris/deploy/nuvolaris-permissions
 ADD deploy/openwhisk-standalone /home/nuvolaris/deploy/openwhisk-standalone

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -167,6 +167,8 @@ tasks:
 
   clean:
     cmds:
+      - cmd: kubectl -n nuvolaris delete wsku --all
+        ignore_error: true    
       - cmd: kubectl -n nuvolaris delete wsk/controller
         ignore_error: true
       - cmd: kubectl -n nuvolaris delete all --all

--- a/TaskfileDev.yml
+++ b/TaskfileDev.yml
@@ -51,6 +51,7 @@ tasks:
       CONTROLLER_TAG: "{{.CONTROLLER_TAG}}"
       OPERATOR_TAG: "{{.OPERATOR_TAG}}"
       COUCHDB_SERVICE_HOST: "localhost"
+      MINIO_API_HOST: "localhost"
 
   instance:
     -  envsubst <{{.CONFIG}} | kubectl -n nuvolaris apply -f -

--- a/TaskfileDev.yml
+++ b/TaskfileDev.yml
@@ -50,6 +50,7 @@ tasks:
       CONTROLLER_IMAGE: "{{.CONTROLLER_IMAGE}}"
       CONTROLLER_TAG: "{{.CONTROLLER_TAG}}"
       OPERATOR_TAG: "{{.OPERATOR_TAG}}"
+      COUCHDB_SERVICE_HOST: "localhost"
 
   instance:
     -  envsubst <{{.CONFIG}} | kubectl -n nuvolaris apply -f -

--- a/TaskfileTest.yml
+++ b/TaskfileTest.yml
@@ -29,7 +29,7 @@ vars:
 
   WHISK: '{{default "whisk" .WHISK}}'
   CONFIG: "tests/{{.KUBE}}/{{.WHISK}}.yaml"
-  REDIS_URI: "redis://redis"
+  REDIS_URI: "redis://default:s0meP@ass3@redis"
   MONGO_URI: "mongodb://nuvolaris:s0meP%40ass3@nuvolaris-mongodb-0.nuvolaris-mongodb-svc.nuvolaris.svc.cluster.local:27017/nuvolaris?connectTimeoutMS=60000"
   MONGO_RT: "ghcr.io/nuvolaris/action-nodejs-v14:0.3.0-morpheus.22081008"
   MINIO_RT: "ghcr.io/francescotimperi/action-nodejs-v14:0.3.0-morpheus.23012416"

--- a/deploy/content/index.html
+++ b/deploy/content/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Nuvolaris Static Content landing page</title>    
+</head>
+<body>
+    <p>
+        Welcome to Nuvolaris static content distributor landing page!!!
+    </p>
+</body>
+</html>

--- a/deploy/nginx-static/nginx-static-cm.yaml
+++ b/deploy/nginx-static/nginx-static-cm.yaml
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-static-conf-cm
+  namespace: nuvolaris
+data:
+  default.conf: |
+    server {
+      listen       80;
+      server_name  localhost;
+
+      #access_log  /var/log/nginx/host.access.log  main;
+
+      #location / {
+      #    root   /usr/share/nginx/html;
+      #    index  index.html index.htm;
+      #}
+
+      #rewrite ^/$ ${request_uri}index.html break;
+      #rewrite (.*)/$ /$1/index.html;
+      #rewrite ^([^.]*[^/])$ /$1/ permanent;
+
+      location / {
+          rewrite ^/$ ${request_uri}index.html break;
+          rewrite (.*)/$ $1/index.html;        
+          rewrite ^([^.]*[^/])$ $1/ permanent;
+          
+          proxy_hide_header     x-amz-id-2;
+          proxy_hide_header     x-amz-meta-etag;
+          proxy_hide_header     x-amz-request-id;
+          proxy_hide_header     x-amz-meta-server-side-encryption;
+          proxy_hide_header     x-amz-server-side-encryption;        
+          proxy_set_header Host $http_host;
+
+          proxy_pass http://staticminio.minio.svc.cluster.local:9001/;
+        proxy_redirect     off;
+      }      
+
+      #error_page  404              /404.html;
+
+      # redirect server error pages to the static page /50x.html
+      #
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+          root   /usr/share/nginx/html;
+      }
+
+      # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+      #
+      #location ~ \.php$ {
+      #    proxy_pass   http://127.0.0.1;
+      #}
+
+      # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+      #
+      #location ~ \.php$ {
+      #    root           html;
+      #    fastcgi_pass   127.0.0.1:9000;
+      #    fastcgi_index  index.php;
+      #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+      #    include        fastcgi_params;
+      #}
+
+      # deny access to .htaccess files, if Apache's document root
+      # concurs with nginx's one
+      #
+      #location ~ /\.ht {
+      #    deny  all;
+      #}
+    }

--- a/deploy/nginx-static/nginx-static-dep.yaml
+++ b/deploy/nginx-static/nginx-static-dep.yaml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nuvolaris-static
+  namespace: nuvolaris
+  labels:
+    app: nuvolaris-static
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nuvolaris-static
+  template:
+    metadata:
+      labels:
+        app: nuvolaris-static
+    spec:
+      initContainers:
+      - name: check-minio
+        image: busybox:1.36.0
+        command: ['sh', '-c', "until nslookup minio.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for minio; sleep 2; done"]     
+      containers:
+      - name: nuvolaris-static
+        image: nginx
+        ports:
+        - containerPort: 80
+        volumeMounts:
+          - name: nginx-default-conf
+            mountPath: /etc/nginx/conf.d/default.conf
+            subPath: default.conf
+            readOnly: false
+      volumes:
+        - name: nginx-default-conf
+          configMap:
+            name: nginx-static-conf-cm
+            items:
+              - key: default.conf
+                path: default.conf            

--- a/deploy/nginx-static/nginx-static-service.yaml
+++ b/deploy/nginx-static/nginx-static-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nuvolaris-static-svc
+  labels:
+    app: nuvolaris-static
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: nuvolaris-static
+  sessionAffinity: None

--- a/deploy/nginx-static/nginx-static-sts.yaml
+++ b/deploy/nginx-static/nginx-static-sts.yaml
@@ -16,13 +16,14 @@
 # under the License.
 #
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: nuvolaris-static
   namespace: nuvolaris
   labels:
     app: nuvolaris-static
 spec:
+  serviceName: nuvolaris-static-svc
   replicas: 1
   selector:
     matchLabels:
@@ -35,7 +36,7 @@ spec:
       initContainers:
       - name: check-minio
         image: busybox:1.36.0
-        command: ['sh', '-c', "until nslookup {{minio_host}}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for minio; sleep 2; done"]     
+        command: ['sh', '-c', "until nslookup minio.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for minio; sleep 2; done"]     
       containers:
       - name: nuvolaris-static
         image: nginx
@@ -45,7 +46,7 @@ spec:
           - name: nginx-default-conf
             mountPath: /etc/nginx/conf.d/default.conf
             subPath: default.conf
-            readOnly: true
+            readOnly: false
       volumes:
         - name: nginx-default-conf
           configMap:

--- a/deploy/nuvolaris-operator/operator-pod.yaml
+++ b/deploy/nuvolaris-operator/operator-pod.yaml
@@ -25,6 +25,5 @@ spec:
   containers:
     - name: nuvolaris-operator
       image: ghcr.io/nuvolaris/nuvolaris-operator:latest
-      imagePullPolicy: Always
       command: ["./run.sh"]
       args: ["--verbose"]

--- a/deploy/nuvolaris-permissions/operator-roles.yaml
+++ b/deploy/nuvolaris-permissions/operator-roles.yaml
@@ -27,7 +27,7 @@ rules:
 
 # edit secrets cm po svc pvc ingresses serviceaccounts events
 - apiGroups: [""]
-  resources: ["configmaps", "secrets", "pods", "services", "persistentvolumeclaims", "ingresses","serviceaccounts","events"]
+  resources: ["configmaps", "secrets", "pods", "services", "persistentvolumeclaims", "ingresses","serviceaccounts","events","pods/exec"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 - apiGroups: [""]

--- a/deploy/nuvolaris-permissions/operator-roles.yaml
+++ b/deploy/nuvolaris-permissions/operator-roles.yaml
@@ -49,9 +49,9 @@ rules:
   resources: ["jobs", "cronjobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
-# edit nuvolaris crd
+# edit nuvolaris crds
 - apiGroups: ["nuvolaris.org"]
-  resources: ["whisks","whisks/status"]
+  resources: ["whisks","whisks/status","whisksusers","whisksusers/status"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 # networking.k8s.io

--- a/deploy/nuvolaris-permissions/operator-roles.yaml
+++ b/deploy/nuvolaris-permissions/operator-roles.yaml
@@ -68,6 +68,11 @@ rules:
   resources: ["mongodbcommunity","mongodbcommunity/finalizers","mongodbcommunity/spec","mongodbcommunity/status"]
   verbs: ["get","patch","list","update","watch","create","delete"]
 
+# required for traefik middlewares
+- apiGroups: ["traefik.containo.us"]
+  resources: ["middlewares"]
+  verbs: ["get","patch","list","update","watch","create","delete"]
+
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/nuvolaris-permissions/whisk-user-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-user-crd.yaml
@@ -16,20 +16,38 @@
 # under the License.
 #
 ---
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: whisks-users.nuvolaris.org
+  name: whisksusers.nuvolaris.org
   namespace: nuvolaris
 spec:
   scope: Namespaced
   group: nuvolaris.org
   names:
     kind: WhiskUser
-    plural: whisksUsers
+    plural: whisksusers
     singular: whiskuser
     shortNames:
-      - wsk.user
+      - wsku
   versions:
     - name: v1
       served: true
@@ -49,10 +67,6 @@ spec:
                   type: string
                 namespace:
                   type: string
-              required:
-                - email
-                - password
-                - namespace
                 redis:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -95,6 +109,10 @@ spec:
                       type: string
                     password:
                       type: string
+              required:
+                - email
+                - password
+                - namespace 
             status:
               x-kubernetes-preserve-unknown-fields: true
               # type: object

--- a/deploy/nuvolaris-permissions/whisk-user-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-user-crd.yaml
@@ -66,7 +66,7 @@ spec:
                 password:
                   type: string
                 namespace:
-                  type: string
+                  type: string                  
                 redis:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -81,12 +81,26 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                   properties:
-                    enabled:
-                      type: boolean
-                    bucket:
-                      type: string
                     password:
                       type: string
+                    data:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        enabled:
+                          type: boolean
+                        bucket:
+                          type: string
+                    route:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        enabled:
+                          type: boolean
+                        bucket:
+                          type: string
+                        host:
+                          type: string
                 mongodb:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -94,18 +108,6 @@ spec:
                     enabled:
                       type: boolean
                     database:
-                      type: string
-                    password:
-                      type: string
-                route:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                  properties:
-                    enabled:
-                      type: boolean
-                    host:
-                      type: string
-                    bucket:
                       type: string
                     password:
                       type: string
@@ -149,10 +151,10 @@ spec:
         - name: ObjectStorage
           type: string
           priority: 0
-          jsonPath: .status.whisk_user_create.s3bucket
+          jsonPath: .status.whisk_user_create.storage_data
           description: ObjectStorage
         - name: Route
           type: string
           priority: 0
-          jsonPath: .status.whisk_user_create.minio
-          description: Route                              
+          jsonPath: .status.whisk_user_create.storage_route
+          description: Route                         

--- a/deploy/nuvolaris-user/whisk-user-crd.yaml
+++ b/deploy/nuvolaris-user/whisk-user-crd.yaml
@@ -1,0 +1,140 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: whisks-users.nuvolaris.org
+  namespace: nuvolaris
+spec:
+  scope: Namespaced
+  group: nuvolaris.org
+  names:
+    kind: WhiskUser
+    plural: whisksUsers
+    singular: whiskuser
+    shortNames:
+      - wsk.user
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources: { status: { } } 
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+                namespace:
+                  type: string
+              required:
+                - email
+                - password
+                - namespace
+                redis:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    enabled:
+                      type: boolean
+                    prefix:
+                      type: string
+                    password:
+                      type: string
+                object-storage:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    enabled:
+                      type: boolean
+                    bucket:
+                      type: string
+                    password:
+                      type: string
+                mongodb:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    enabled:
+                      type: boolean
+                    database:
+                      type: string
+                    password:
+                      type: string
+                route:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    enabled:
+                      type: boolean
+                    host:
+                      type: string
+                    bucket:
+                      type: string
+                    password:
+                      type: string
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+              # type: object
+              # properties:
+              #   wsk_user_create:
+              #     type: object
+              #     properties:
+              #       couchdb:
+              #         type: string
+              #       mongodb:
+              #         type: string
+              #       redis:
+              #         type: string
+              #       object-storage:
+              #         type: string
+              #       route:
+              #         type: string                            
+      additionalPrinterColumns:
+        - name: CouchDB
+          type: string
+          priority: 0
+          jsonPath: .status.whisk_user_create.couchdb
+          description: CouchDB
+        - name: MongoDB
+          type: string
+          priority: 0
+          jsonPath: .status.whisk_user_create.mongodb
+          description: MongoDB
+        - name: Redis
+          type: string
+          priority: 0
+          jsonPath: .status.whisk_user_create.redis
+          description: Redis
+        - name: ObjectStorage
+          type: string
+          priority: 0
+          jsonPath: .status.whisk_user_create.s3bucket
+          description: ObjectStorage
+        - name: Route
+          type: string
+          priority: 0
+          jsonPath: .status.whisk_user_create.minio
+          description: Route                              

--- a/deploy/redis/_redis-cm.yaml
+++ b/deploy/redis/_redis-cm.yaml
@@ -22,3 +22,7 @@ metadata:
 data:
     redis-conf: |-
                 #requirepass <secure_password>
+                # The format of the external ACL user file is exactly the same as the
+                # format that is used inside redis.conf to describe users.
+                #
+                aclfile /etc/users.acl

--- a/deploy/redis/redis-set.yaml
+++ b/deploy/redis/redis-set.yaml
@@ -31,13 +31,11 @@ spec:
       labels:
         name: redis
     spec:
-      restartPolicy: Always
+      restartPolicy: Always  
       containers:
       - name: redis
-        image: redis:5.0.4
-        command:
-          - redis-server
-          - "/redis-master/redis.conf"
+        image: redis:7.0.10
+        command: ["/bin/sh","-c","redis-server /redis-master/redis.conf"]
         env:
         - name: MASTER
           value: "true"

--- a/nuvolaris/config.py
+++ b/nuvolaris/config.py
@@ -137,6 +137,22 @@ def detect():
     detect_labels()
     detect_env()
 
+def detect_ingress_class():
+    runtime = _config['nuvolaris.kube']
+
+    # ingress class default to nginx
+    ingress_class = "nginx"
+
+    # On microk8s ingress class must be public
+    if runtime == "microk8s":
+        ingress_class = "public"
+
+    # On k3s ingress class must be traefik
+    if runtime == "k3s":
+        ingress_class = "traefik" 
+    
+    return ingress_class
+
 def dump_config():
     import nuvolaris.config as cfg
     for k in cfg.getall():

--- a/nuvolaris/config.py
+++ b/nuvolaris/config.py
@@ -39,12 +39,13 @@ def exists(key):
 
 def get(key, envvar=None, defval=None):
     val = _config.get(key)
-    if val: 
-        return val
+
     if envvar and envvar in os.environ:
         val = os.environ[envvar]
+    
     if val: 
         return val
+    
     return defval
 
 def put(key, value):

--- a/nuvolaris/couchdb.py
+++ b/nuvolaris/couchdb.py
@@ -192,7 +192,7 @@ def create_ow_user(subject, auth):
         else:
             return None
     except Exception as e:
-        logging.error('failed to authorize Openwhisk namespace %s authorization id and key: %s' % subject, e)
+        logging.error(f"failed to authorize Openwhisk namespace {subject} authorization id and key: {e}")
         return None
 
 def delete_ow_user(subject):
@@ -213,7 +213,7 @@ def delete_ow_user(subject):
         logging.warn(f"auhorization for OpenWhisk namespace {subject} not found!")
         return None
     except Exception as e:
-        logging.error('failed to remove Openwhisk namespace %s authorization id and key: %s' % subject, e)
+        logging.error(f"failed to remove Openwhisk namespace {subject} authorization id and key: {e}")
         return None
 
 

--- a/nuvolaris/couchdb_util.py
+++ b/nuvolaris/couchdb_util.py
@@ -24,7 +24,7 @@ class CouchDB:
     self.db_protocol   = "http"
     self.db_prefix     = "nuvolaris_"
     self.db_port       = cfg.get("couchdb.port", "COUCHDB_SERVICE_PORT", "5984")
-    self.db_host       = cfg.get("couchdb.host", "COUCHDB_SERVICE_HOST", "localhost")
+    self.db_host       = cfg.get("couchdb.host", "COUCHDB_SERVICE_HOST", "couchdb")
     self.db_username   = cfg.get("couchdb.admin.user", "COUCHDB_ADMIN_USER", "whisk_admin")
     self.db_password   = cfg.get("couchdb.admin.password", "COUCHDB_ADMIN_PASSWORD", "some_passw0rd")
     self.db_auth = req.auth.HTTPBasicAuth(self.db_username,self.db_password)

--- a/nuvolaris/endpoint.py
+++ b/nuvolaris/endpoint.py
@@ -47,18 +47,8 @@ def create(owner=None):
     openwhisk.annotate(f"apihost={apihost}")
     url = urllib.parse.urlparse(apihost)
 
-    hostname = url.hostname
-
-    # ingress class default to nginx
-    ingress_class = "nginx"
-
-    # On microk8s ingress class must be public
-    if runtime == "microk8s":
-        ingress_class = "public"
-
-    # On k3s ingress class must be traefik
-    if runtime == "k3s":
-        ingress_class = "traefik" 
+    hostname = url.hostname    
+    ingress_class = cfg.detect_ingress_class()
 
     data = {
         "hostname":hostname,

--- a/nuvolaris/kustomize.py
+++ b/nuvolaris/kustomize.py
@@ -164,7 +164,7 @@ def configMapTemplate(name, where, template, data):
   - {template}=__{template}
 """
 
-# genearate a patch from a template
+# generate a patch from a template
 def patchTemplate(where, template, data):
     """   
     >>> import nuvolaris.testutil as tu

--- a/nuvolaris/main.py
+++ b/nuvolaris/main.py
@@ -148,7 +148,7 @@ def whisk_create(spec, name, **kwargs):
         logging.info(msg)
         state['static'] = "on"
     else:
-        state['static'] = "off"        
+        state['static'] = "off"         
     
     if cfg.get('components.kafka'):
         logging.warn("invoker not yet implemented")
@@ -214,13 +214,15 @@ def whisk_delete(spec, **kwargs):
         msg = cron.delete()
         logging.info(msg)
 
+    if cfg.get('components.static'):
+        msg = static.delete()
+        logging.info(msg) 
+
     if cfg.get("components.minio"):
         msg = minio.delete()
         logging.info(msg)
 
-    if cfg.get('components.static'):
-        msg = static.delete
-        logging.info(msg)              
+             
     
                          
 # tested by integration test

--- a/nuvolaris/main.py
+++ b/nuvolaris/main.py
@@ -30,6 +30,7 @@ import nuvolaris.issuer as issuer
 import nuvolaris.endpoint as endpoint
 import nuvolaris.minio as minio
 import nuvolaris.openwhisk_patcher as patcher
+import nuvolaris.nginx_static as static
 
 # tested by an integration test
 @kopf.on.login()
@@ -65,7 +66,9 @@ def whisk_create(spec, name, **kwargs):
         "endpoint": "?", # Http/s controller endpoint # Http/s controller endpoint
         "issuer": "?", # ClusterIssuer configuration
         "ingress": "?", # Ingress configuration
-        "minio": "?" # Minio configuration
+        "minio": "?", # Minio configuration
+        "static": "?", # Minio static endpoint provider
+        "zookeeper": "?" #Zookeeper configuration
     }
 
     runtime = cfg.get('nuvolaris.kube')
@@ -139,6 +142,13 @@ def whisk_create(spec, name, **kwargs):
         state['minio'] = "on"
     else:
         state['minio'] = "off"
+
+    if cfg.get('components.static'):
+        msg = static.create(owner)
+        logging.info(msg)
+        state['static'] = "on"
+    else:
+        state['static'] = "off"        
     
     if cfg.get('components.kafka'):
         logging.warn("invoker not yet implemented")
@@ -206,7 +216,11 @@ def whisk_delete(spec, **kwargs):
 
     if cfg.get("components.minio"):
         msg = minio.delete()
-        logging.info(msg)       
+        logging.info(msg)
+
+    if cfg.get('components.static'):
+        msg = static.delete
+        logging.info(msg)              
     
                          
 # tested by integration test

--- a/nuvolaris/minio.py
+++ b/nuvolaris/minio.py
@@ -25,13 +25,14 @@ def create(owner=None):
     logging.info(f"*** configuring minio standalone")
 
     data = {
+        "minio_host": cfg.get('minio.host') or "minio",
         "minio_volume_size": cfg.get('minio.volume-size') or "5",
         "minio_root_user": cfg.get('minio.nuvolaris.root-user') or "minio",
         "minio_root_password": cfg.get('minio.nuvolaris.root-password') or "minio123",
         "storage_class": cfg.get("nuvolaris.storageClass")
     }
     
-    kust = kus.patchTemplates("minio", ["00-minio-pvc.yaml","01-minio-dep.yaml"], data)    
+    kust = kus.patchTemplates("minio", ["00-minio-pvc.yaml","01-minio-dep.yaml","02-minio-svc.yaml"], data)    
     spec = kus.kustom_list("minio", kust, templates=[], data=data)
 
     if owner:

--- a/nuvolaris/minio_util.py
+++ b/nuvolaris/minio_util.py
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# this module wraps mc minio client
+
+import logging
+import json
+import subprocess
+import nuvolaris.config as cfg
+import nuvolaris.template as ntp
+import os
+
+class MinioClient:
+    
+    def __init__(self):
+        self.minio_api_host   = cfg.get("minio.host", "MINIO_API_HOST", "localhost")
+        self.minio_api_port   = cfg.get("9000", "MINIO_API_PORT", "9000")        
+        self.admin_username   = cfg.get("minio.nuvolaris.root-user", "MINIO_ADMIN_USER", "minioadmin")
+        self.admin_password   = cfg.get("minio.nuvolaris.root-password", "MINIO_ADMIN_PASSWORD", "minioadmin")
+        self.minio_api_url   = f"http://{self.minio_api_host}:{self.minio_api_port}"
+        self.alias = "local"        
+
+        # automatically adds the nuv_minio alias to map the deployed minio instance
+        self.mc("alias","set", self.alias, self.minio_api_url, self.admin_username, self.admin_password)
+
+    def check(self,f, what, res):
+        if f:
+            logging.info(f"OK: {what}")
+            return res and True
+        else:
+            logging.warn(f"ERR: {what}")
+            return False        
+
+    # execute minio commands using the mc cli tools installed by default inside the operator
+    def mc(self, *kwargs):        
+        cmd = ["mc"]
+        cmd += list(kwargs)
+
+        # executing
+        logging.debug(cmd)
+        try:
+            res = subprocess.run(cmd, capture_output=True)
+
+            returncode = res.returncode
+            output = res.stdout.decode()
+            error = res.stderr.decode()
+            
+            if returncode != 0:
+                logging.error(error)
+            else:
+                logging.info(output)
+
+            return returncode == 0
+        except Exception as e:
+                        logging.error(e)
+                        return e
+
+    def add_user(self, username, access_secret):
+        """
+        adds a new minio user to the configured minio instance
+        """
+        return self.check(self.mc("admin","user","add", self.alias, username, access_secret),"add_user",True)
+
+    def make_bucket(self, bucket_name):
+        """
+        adds a new bucket inside the configured minio instance 
+        """
+        return self.check(self.mc("mb",f"{self.alias}/{bucket_name}"),"make_bucket",True)
+
+    def make_public_bucket(self, bucket_name):
+        """
+        adds a new public bucket to the configured minio instance 
+        """
+        res = self.check(self.make_bucket(bucket_name),"make_bucket",True)
+        return self.check(self.mc("anonymous","-r","set","download",f"{self.alias}/{bucket_name}"),"make_public_bucket",res)
+
+    def assign_policy_to_user(self, username, policy):
+        """
+        assign the specified policy to the given username
+        """        
+        return self.check(self.mc("admin","policy","set",self.alias,policy,f"user={username}"),"assign_policy_to_user",True)
+
+    def add_policy(self, policy, path_to_policy_json):
+        """
+        add a new policy into minio
+        """        
+        return self.check(self.mc("admin","policy","add",self.alias,policy,path_to_policy_json),"add_policy",True)        
+
+    def remove_policy(self, policy):
+        """
+        add a new policy into minio
+        """        
+        return self.check(self.mc("admin","policy","remove",self.alias,policy),"remove_policy",True)
+
+    def render_policy(self,bucket,template,data):
+        """
+        uses the given template policy to render a final policy and returns the absolute path to rendered policy file.
+        """  
+        out = f"/tmp/__{bucket}_{template}"
+        file = ntp.spool_template(template, out, data)
+        return os.path.abspath(file)
+    
+    def assign_rw_bucket_policy_to_user(self,username,bucket_name):
+        """
+        defines a rw policy template for the specified bucket and assigns it to the given username.
+        """          
+        policy_name = f"{username}_{bucket_name}_rw_policy"
+        path_to_policy_json = self.render_policy(bucket_name,"minio_rw_policy_tpl.json",{"bucket_arn":f"{bucket_name}/*"})        
+        res=self.check(self.add_policy(policy_name,path_to_policy_json),"add_policy",True)
+        res=self.check(self.assign_policy_to_user(username,policy_name),"assign_rw_bucket_policy_to_user",res)
+        os.remove(path_to_policy_json)
+        return res
+
+
+

--- a/nuvolaris/mongodb.py
+++ b/nuvolaris/mongodb.py
@@ -25,7 +25,10 @@ import nuvolaris.config as cfg
 import nuvolaris.util as util
 import nuvolaris.mongodb_operator as operator
 import nuvolaris.mongodb_standalone as standalone
+import nuvolaris.kube as kube
+import nuvolaris.template as ntp
 import logging
+import os
 
 def create(owner=None):
     """
@@ -50,3 +53,61 @@ def delete():
 
 def init():
     return "TODO"
+
+def render_mongodb_script(namespace,template,data):
+    """
+    uses the given template to render a js script to execute as a json.
+    """  
+    out = f"/tmp/__{namespace}_{template}"
+    file = ntp.spool_template(template, out, data)
+    return os.path.abspath(file)
+
+def exec_mongosh_command(pod_name,path_to_mdb_script):
+    logging.info(f"passing script {path_to_mdb_script} to pod {pod_name}")
+    res = kube.kubectl("cp",path_to_mdb_script,f"{pod_name}:{path_to_mdb_script}")
+    res = kube.kubectl("exec","-it",pod_name,"--","/bin/bash","-c",f"mongosh --file {path_to_mdb_script}")
+    os.remove(path_to_mdb_script)
+    return res
+
+def create_db_user(namespace, database, auth):
+    logging.info(f"authorizing new mongodb database {database}")
+
+    try:
+        data = util.get_mongodb_config_data()
+        data["subject"]=namespace
+        data["database"]=database
+        data["auth"]=auth
+        data["mode"]="create"
+
+        path_to_mdb_script = render_mongodb_script(namespace,"mongodb_manage_user_tpl.js",data)
+        pod_name = util.get_pod_name("{.items[?(@.metadata.labels.app == 'nuvolaris-mongodb')].metadata.name}")
+
+        if(pod_name):
+            res = exec_mongosh_command(pod_name,path_to_mdb_script)
+            return res
+
+        return None
+    except Exception as e:
+        logging.error(f"failed to add Mongodb database {database}: {e}")
+        return None
+
+def delete_db_user(namespace, database):
+    logging.info(f"removing mongodb database {database}")
+
+    try:
+        data = util.get_mongodb_config_data()
+        data["subject"]=namespace
+        data["database"]=database
+        data["mode"]="delete"
+
+        path_to_mdb_script = render_mongodb_script(namespace,"mongodb_manage_user_tpl.js",data)
+        pod_name = util.get_pod_name("{.items[?(@.metadata.labels.app == 'nuvolaris-mongodb')].metadata.name}")
+
+        if(pod_name):
+            res = exec_mongosh_command(pod_name,path_to_mdb_script)
+            return res
+
+        return None
+    except Exception as e:
+        logging.error(f"failed to remove Mongodb database {namespace} authorization id and key: {e}")
+        return None    

--- a/nuvolaris/nginx_static.py
+++ b/nuvolaris/nginx_static.py
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import kopf, logging, json, os
+import nuvolaris.kube as kube
+import nuvolaris.kustomize as kus
+import nuvolaris.config as cfg
+import nuvolaris.util as util
+import nuvolaris.template as ntp
+
+def create(owner=None):
+    logging.info(f"*** configuring nuvolaris nginx static provider")
+
+    data = {
+        "minio_host": cfg.get('minio.host') or "minio",
+        "minio_post": cfg.get('minio.port') or "9000",
+    }
+    
+    kust = kus.patchTemplates("nginx-static", ["nginx-static-cm.yaml","nginx-static-dep.yaml"], data)    
+    spec = kus.kustom_list("nginx-static", kust, templates=[], data=data)
+
+    if owner:
+        kopf.append_owner_reference(spec['items'], owner)
+    else:
+        cfg.put("state.ngix-static.spec", spec)
+
+    res = kube.apply(spec)
+
+    logging.info("*** configured nuvolaris nginx static provider")
+    return res
+
+def delete():
+    spec = cfg.get("state.ngix-static.spec")
+    res = False
+    if spec:
+        res = kube.delete(spec)
+        logging.info(f"delete nuvolaris nginx static provider: {res}")
+    return res
+
+def static_ingress_name(namespace):
+    return f"{namespace}-static-ingress"
+
+def static_secret_name(namespace):
+    return f"{namespace}-static-secret"
+
+def render_ingress_template(namespace,template,data):
+    """
+    uses the given template policy to render a final ingress template.
+    """  
+    out = f"/tmp/__{namespace}_{template}"
+    file = ntp.spool_template(template, out, data)
+    return os.path.abspath(file)      
+
+def create_ow_static_endpoint(ucfg, owner=None):
+    namespace = ucfg.get("namespace")
+    logging.info(f"*** configuring static endpoint for {namespace}")
+
+    runtime = cfg.get('nuvolaris.kube')
+    host = ucfg.get('object-storage.route.host')
+    bucket = ucfg.get('object-storage.route.bucket')
+    tls = cfg.get('components.tls') and not runtime=='kind'
+    ingress_class = cfg.detect_ingress_class()
+    context_path = tls and "/" or f"/{bucket}"
+
+    data = {
+        "namespace":namespace,
+        "ingress_name": static_ingress_name(namespace),
+        "secret_name": static_secret_name(namespace),
+        "ingress_class": ingress_class,
+        "tls": tls,
+        "hostname": host,        
+        "rewrite_target":f"/{bucket}/$1",
+        "nginx_static_service": "nuvolaris-static-svc",
+        "nginx_static_service_port": 80,
+        "context_path":context_path
+    }
+
+    try:
+        path_to_template_yaml = render_ingress_template(namespace,"static-ingress-tpl.yaml",data)
+        res = kube.kubectl("apply", "-f",path_to_template_yaml)
+        os.remove(path_to_template_yaml)
+        return res
+    except Exception as e:
+        logging.warn(e)       
+        return False
+
+def delete_ow_static_endpoint(ucfg):
+    namespace = ucfg.get("namespace")
+    logging.info(f"*** removing static endpoint for {namespace}")
+    
+    try:
+        ingress_name = static_ingress_name(namespace)
+        return kube.kubectl("delete", "ingress",ingress_name)
+    except Exception as e:
+        logging.warn(e)       
+        return False           

--- a/nuvolaris/policies/minio_rw_policy_tpl.json
+++ b/nuvolaris/policies/minio_rw_policy_tpl.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::{{bucket_arn}}"
+      ]
+    }
+  ]
+}

--- a/nuvolaris/policies/minio_rw_policy_tpl.json
+++ b/nuvolaris/policies/minio_rw_policy_tpl.json
@@ -7,7 +7,12 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::{{bucket_arn}}"
+        {% for bucket_arn in bucket_arns -%}
+          "arn:aws:s3:::{{bucket_arn}}"
+          {% if not loop.last %}
+          ,
+          {% endif %}
+        {% endfor %}
       ]
     }
   ]

--- a/nuvolaris/redis.py
+++ b/nuvolaris/redis.py
@@ -19,6 +19,8 @@
 import nuvolaris.kustomize as kus
 import nuvolaris.kube as kube
 import nuvolaris.config as cfg
+import nuvolaris.template as ntp
+import nuvolaris.util as util
 import urllib.parse
 import os, os.path
 import logging
@@ -27,12 +29,7 @@ import kopf
 
 def create(owner=None):
     logging.info("create redis")
-    data = {
-        "name": "redis",
-        "dir": "/redis-master-data",
-        "size": cfg.get("couchdb.volume-size", "REDIS_VOLUME_SIZE", 10),
-        "storageClass": cfg.get("nuvolaris.storageClass")
-    }
+    data = util.get_redis_config_data()
     kust = kus.patchTemplate("redis", "set-attach.yaml", data)
     spec = kus.kustom_list("redis", kust, templates=["redis-conf.yaml"], data=data)
 
@@ -41,9 +38,15 @@ def create(owner=None):
     else:
         cfg.put("state.redis.spec", spec)
     res = kube.apply(spec)
+
+    wait_for_redis_ready()
+
     logging.info(f"create redis: {res}")
     return res
 
+def wait_for_redis_ready():
+    # dynamically detect redis pod and wait for readiness
+    util.wait_for_pod_ready("{.items[?(@.metadata.labels.name == 'redis')].metadata.name}")
 
 def delete():
     spec = cfg.get("state.redis.spec")
@@ -52,4 +55,61 @@ def delete():
         res = kube.delete(spec)
         logging.info(f"delete redis: {res}")
     return res
+
+def render_redis_script(namespace,template,data):
+    """
+    uses the given template to render a redis-cli script to be executed.
+    """  
+    out = f"/tmp/__{namespace}_{template}"
+    file = ntp.spool_template(template, out, data)
+    return os.path.abspath(file)
+
+def exec_redis_command(pod_name,path_to_script):
+    logging.info(f"passing script {path_to_script} to pod {pod_name}")
+    res = kube.kubectl("cp",path_to_script,f"{pod_name}:{path_to_script}")
+    res = kube.kubectl("exec","-it",pod_name,"--","/bin/bash","-c",f"cat {path_to_script} | redis-cli")
+    os.remove(path_to_script)
+    return res
+
+def create_db_user(namespace,prefix,auth):
+    logging.info(f"authorizing new redis namespace {namespace}")    
+    try:
+        wait_for_redis_ready()
+        data = util.get_redis_config_data()
+        data['namespace']=namespace
+        data['password']=auth
+        data['prefix']=prefix
+        data['mode']="create"
+
+        path_to_script = render_redis_script(namespace,"redis_manage_user_tpl.txt",data)
+        pod_name = util.get_pod_name("{.items[?(@.metadata.labels.name == 'redis')].metadata.name}")
+
+        if(pod_name):
+            res = exec_redis_command(pod_name,path_to_script)
+            return res
+
+        return None
+    except Exception as e:
+        logging.error(f"failed to add redis namespace {namespace}: {e}")
+        return None
+
+def delete_db_user(namespace):
+    logging.info(f"removing redis namespace {namespace}")
+
+    try:        
+        data = util.get_redis_config_data()
+        data["namespace"]=namespace
+        data["mode"]="delete"
+
+        path_to_script = render_redis_script(namespace,"redis_manage_user_tpl.txt",data)
+        pod_name = util.get_pod_name("{.items[?(@.metadata.labels.name == 'redis')].metadata.name}")
+
+        if(pod_name):
+            res = exec_redis_command(pod_name,path_to_script)
+            return res
+
+        return None
+    except Exception as e:
+        logging.error(f"failed to remove redis namespace {namespace}: {e}")
+        return None     
 

--- a/nuvolaris/template.py
+++ b/nuvolaris/template.py
@@ -18,7 +18,7 @@
 import os
 
 from jinja2 import Environment, FileSystemLoader
-loader = FileSystemLoader(["./nuvolaris/templates", "./nuvolaris/files"])
+loader = FileSystemLoader(["./nuvolaris/templates", "./nuvolaris/files", "./nuvolaris/policies"])
 env = Environment(loader=loader)
 
 # expand template

--- a/nuvolaris/templates/02-minio-svc.yaml
+++ b/nuvolaris/templates/02-minio-svc.yaml
@@ -15,30 +15,23 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-[tool.poetry]
-name = "nuvolaris"
-version = "0.3.0"
-description = "Nuvolaris operator"
-authors = ["Michele Sciabarra <michele@sciabarra.com>"]
-
-[tool.poetry.dependencies]
-python = "^3.9"
-kopf = {extras = ["full-auth"], version = "^1.35.3"}
-PyYAML = "^6.0"
-pykube = "^0.15.0"
-Jinja2 = "^3.0.3"
-requests = "^2.27.1"
-flatdict = "^4.0.1"
-croniter = "^1.3.5"
-minio = "^7.1.13"
-
-[tool.poetry.dev-dependencies]
-ipython = "^7.31.0"
-
-[tool.poetry.scripts]
-dbinit = "nuvolaris.couchdb:init"
-actionexecutor = "nuvolaris.actionexecutor:start"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{minio_host}}
+spec:
+  type: NodePort
+  ports:
+    - port: 9000
+      targetPort: 9000
+      nodePort: 32090
+      protocol: TCP
+      name: minio-api
+    - port: 9090
+      targetPort: 9090
+      nodePort: 32091
+      protocol: TCP
+      name: minio-console      
+  selector:
+    app: minio

--- a/nuvolaris/templates/mongodb_manage_user_tpl.js
+++ b/nuvolaris/templates/mongodb_manage_user_tpl.js
@@ -1,0 +1,19 @@
+conn = Mongo("mongodb://{{mongo_admin_user}}:{{mongo_admin_password}}@127.0.0.1:27017")
+db = conn.getDB('admin')
+db = db.getSiblingDB('{{database}}');
+
+{% if mode == 'create'%}
+db.createUser({
+    user: "{{subject}}",
+    pwd: "{{auth}}",
+    roles: [
+        {role: "readWrite", db: "{{subject}}"}
+    ]
+});
+db.nuv_test_collection.insertOne({"message":"Welcome to nuvolaris!"});
+{% endif %}
+
+{% if mode == 'delete'%}
+db.dropUser("{{subject}}", {w: "majority", wtimeout: 4000});
+db.dropDatabase();
+{% endif %}

--- a/nuvolaris/templates/nginx-static-cm.yaml
+++ b/nuvolaris/templates/nginx-static-cm.yaml
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-static-conf-cm
+  namespace: nuvolaris
+data:
+  default.conf: |
+    server {
+      listen       80;
+      server_name  localhost;
+
+      #access_log  /var/log/nginx/host.access.log  main;
+
+      #location / {
+      #    root   /usr/share/nginx/html;
+      #    index  index.html index.htm;
+      #}
+
+      #rewrite ^/$ ${request_uri}index.html break;
+      #rewrite (.*)/$ /$1/index.html;
+      #rewrite ^([^.]*[^/])$ /$1/ permanent;
+
+      location / {
+          rewrite ^/$ ${request_uri}index.html break;
+          rewrite (.*)/$ $1/index.html;        
+          rewrite ^([^.]*[^/])$ $1/ permanent;
+          
+          proxy_hide_header     x-amz-id-2;
+          proxy_hide_header     x-amz-meta-etag;
+          proxy_hide_header     x-amz-request-id;
+          proxy_hide_header     x-amz-meta-server-side-encryption;
+          proxy_hide_header     x-amz-server-side-encryption;        
+          proxy_set_header Host $http_host;
+
+          proxy_pass http://{{minio_host}}.nuvolaris.svc.cluster.local:{{minio_post}}/;
+        proxy_redirect     off;
+      }      
+
+      #error_page  404              /404.html;
+
+      # redirect server error pages to the static page /50x.html
+      #
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+          root   /usr/share/nginx/html;
+      }
+
+      # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+      #
+      #location ~ \.php$ {
+      #    proxy_pass   http://127.0.0.1;
+      #}
+
+      # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+      #
+      #location ~ \.php$ {
+      #    root           html;
+      #    fastcgi_pass   127.0.0.1:9000;
+      #    fastcgi_index  index.php;
+      #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+      #    include        fastcgi_params;
+      #}
+
+      # deny access to .htaccess files, if Apache's document root
+      # concurs with nginx's one
+      #
+      #location ~ /\.ht {
+      #    deny  all;
+      #}
+    }    

--- a/nuvolaris/templates/nginx-static-dep.yaml
+++ b/nuvolaris/templates/nginx-static-dep.yaml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nuvolaris-static
+  namespace: nuvolaris
+  labels:
+    app: nuvolaris-static
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nuvolaris-static
+  template:
+    metadata:
+      labels:
+        app: nuvolaris-static
+    spec:
+      initContainers:
+      - name: check-minio
+        image: busybox:1.36.0
+        command: ['sh', '-c', "until nslookup {{minio_host}}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for minio; sleep 2; done"]     
+      containers:
+      - name: nuvolaris-static
+        image: nginx
+        ports:
+        - containerPort: 80
+        volumeMounts:
+          - name: nginx-default-conf
+            mountPath: /etc/nginx/conf.d/default.conf
+            subPath: default.conf
+            readOnly: true
+      volumes:
+        - name: nginx-default-conf
+          configMap:
+            name: nginx-static-conf-cm
+            items:
+              - key: default.conf
+                path: default.conf            

--- a/nuvolaris/templates/nginx-static-sts.yaml
+++ b/nuvolaris/templates/nginx-static-sts.yaml
@@ -16,13 +16,14 @@
 # under the License.
 #
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: nuvolaris-static
   namespace: nuvolaris
   labels:
     app: nuvolaris-static
 spec:
+  serviceName: nuvolaris-static-svc
   replicas: 1
   selector:
     matchLabels:
@@ -35,7 +36,7 @@ spec:
       initContainers:
       - name: check-minio
         image: busybox:1.36.0
-        command: ['sh', '-c', "until nslookup minio.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for minio; sleep 2; done"]     
+        command: ['sh', '-c', "until nslookup {{minio_host}}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for minio; sleep 2; done"]     
       containers:
       - name: nuvolaris-static
         image: nginx
@@ -45,7 +46,7 @@ spec:
           - name: nginx-default-conf
             mountPath: /etc/nginx/conf.d/default.conf
             subPath: default.conf
-            readOnly: false
+            readOnly: true
       volumes:
         - name: nginx-default-conf
           configMap:

--- a/nuvolaris/templates/redis-conf.yaml
+++ b/nuvolaris/templates/redis-conf.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: nuvolaris
 data:
     redis-conf: |
-                #requirepass <secure_password>
+                requirepass {{redis_password}}           
 
 
 

--- a/nuvolaris/templates/redis_manage_user_tpl.txt
+++ b/nuvolaris/templates/redis_manage_user_tpl.txt
@@ -1,0 +1,13 @@
+AUTH {{redis_password}}
+{% if mode == 'create'%}
+ACL SETUSER {{namespace}}
+ACL SETUSER {{namespace}} ON >{{password}}
+ACL SETUSER {{namespace}} +SET
+ACL SETUSER {{namespace}} +GET
+ACL SETUSER {{namespace}} +DEL
+ACL SETUSER {{namespace}} ~{{prefix}}:*
+{% endif %}
+
+{% if mode == 'delete'%}
+ACL DELUSER {{namespace}}
+{% endif %}

--- a/nuvolaris/templates/static-ingress-tpl.yaml
+++ b/nuvolaris/templates/static-ingress-tpl.yaml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ingress_name}}
+  namespace: nuvolaris
+  annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: "48m"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+      kubernetes.io/ingress.class: "{{ingress_class}}"
+      {% if tls %}
+      cert-manager.io/cluster-issuer: "letsencrypt-issuer"
+      nginx.ingress.kubernetes.io/use-regex: "true"
+      nginx.ingress.kubernetes.io/rewrite-target: {{rewrite_target}}
+      {% endif %}
+spec:
+  {% if tls %}
+  tls:
+    - hosts:
+      - {{hostname}}
+      secretName: {{secret_name}}
+  {% endif %}      
+  rules:
+    - host: "{{hostname}}"
+      http:
+        paths:
+          - path: {{context_path}}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{nginx_static_service}}
+                port: 
+                  number: {{nginx_static_service_port}}

--- a/nuvolaris/templates/static-ingress-tpl.yaml
+++ b/nuvolaris/templates/static-ingress-tpl.yaml
@@ -15,22 +15,28 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ingress_name}}
   namespace: nuvolaris
   annotations:
+      kubernetes.io/ingress.class: "{{ingress_class}}"
+      {% if tls %}
+      cert-manager.io/cluster-issuer: "letsencrypt-issuer"
+      {% endif %}
+      {% if tls and not ingress_class=='traefik'%}
       nginx.ingress.kubernetes.io/proxy-body-size: "48m"
       nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-      kubernetes.io/ingress.class: "{{ingress_class}}"
-      {% if tls %}
-      cert-manager.io/cluster-issuer: "letsencrypt-issuer"
       nginx.ingress.kubernetes.io/use-regex: "true"
-      nginx.ingress.kubernetes.io/rewrite-target: {{rewrite_target}}
+      nginx.ingress.kubernetes.io/rewrite-target: {{rewrite_target}}/$1
       {% endif %}
+      {% if tls and ingress_class=='traefik' %}
+      traefik.ingress.kubernetes.io/router.middlewares: nuvolaris-{{middleware_ingress_name}}@kubernetescrd
+      {% endif %}      
 spec:
   {% if tls %}
   tls:
@@ -48,4 +54,4 @@ spec:
               service:
                 name: {{nginx_static_service}}
                 port: 
-                  number: {{nginx_static_service_port}}
+                  number: {{nginx_static_service_port}} 

--- a/nuvolaris/templates/traefik-prefix-middleware-tpl.yaml
+++ b/nuvolaris/templates/traefik-prefix-middleware-tpl.yaml
@@ -15,16 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-apiVersion: v1
-kind: Pod
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
 metadata:
-  name: nuvolaris-operator
   namespace: nuvolaris
+  name: {{middleware_ingress_name}}
 spec:
-  serviceAccount: nuvolaris-operator
-  containers:
-    - name: nuvolaris-operator
-      image: ghcr.io/nuvolaris/nuvolaris-operator:latest
-      imagePullPolicy: Always
-      command: ["./run.sh"]
-      args: ["--verbose"]
+  addPrefix:
+    prefix: {{rewrite_target}}

--- a/nuvolaris/testutil.py
+++ b/nuvolaris/testutil.py
@@ -252,4 +252,9 @@ def generate_ow_auth():
     """     
     uid = generate_ow_uid()
     key = generate_ow_key()
-    return f"{uid}:{key}"    
+    return f"{uid}:{key}"
+
+def load_sample_user_config(name="whisk-user"):
+    with open(f"tests/{name}.yaml") as f: 
+        c = yaml.safe_load(f)
+        return c['spec']    

--- a/nuvolaris/testutil.py
+++ b/nuvolaris/testutil.py
@@ -21,6 +21,9 @@ import flatdict
 import json
 import time
 import requests as req
+import uuid
+import string
+import random
 
 # takes a string, split in lines and search for the word (a re)
 # if field is a number, splits the line in fields separated by spaces and print the selected field
@@ -224,3 +227,29 @@ def retry(fn, value, max=10, delay=1):
         time.sleep(delay)
         print(i, "retrying...")
     return False
+
+def generate_ow_uid():
+    """
+        >>> import nuvolaris.testutil as util        
+        >>> len(util.generate_ow_uid())
+        36
+    """ 
+    return str(uuid.uuid4())
+
+def generate_ow_key():
+    """
+        >>> import nuvolaris.testutil as util        
+        >>> len(util.generate_ow_key())
+        64
+    """ 
+    return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(64))
+
+def generate_ow_auth():
+    """
+        >>> import nuvolaris.testutil as util        
+        >>> len(util.generate_ow_auth())
+        101
+    """     
+    uid = generate_ow_uid()
+    key = generate_ow_key()
+    return f"{uid}:{key}"    

--- a/nuvolaris/user_config.py
+++ b/nuvolaris/user_config.py
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import flatdict, json, os
+import logging
+
+class UserConfig:
+    _config = {}
+
+    def __init__(self, spec):
+        self.configure(spec)
+        pass
+
+    # define a configuration 
+    # the configuration is a map, followed by a list of labels 
+    # the map can be a serialized json and will be flattened to a map of values.
+    # you can have only a configuration active at a time
+    # if you want to set a new configuration you have to clean it
+    def configure(self,spec: dict):
+        self._config = dict(flatdict.FlatDict(spec, delimiter="."))
+        return True
+
+    def clean(self):    
+        self._config = {}
+
+    def exists(self,key):
+        return key in self._config
+
+    def get(self,key, envvar=None, defval=None):
+        val = self._config.get(key)
+
+        if envvar and envvar in os.environ:
+            val = os.environ[envvar]
+        
+        if val: 
+            return val
+        
+        return defval
+
+    def put(self,key, value):
+        self._config[key] = value
+        return True
+
+    def delete(self, key):
+        if key in self._config:
+            del self._config[key]
+            return True
+
+    def getall(self,prefix=""):
+        res = {}
+        for key in self._config.keys():
+            if key.startswith(prefix):
+                res[key] = self._config[key]
+        return res
+
+    def keys(self, prefix=""):
+        res = []
+        if self._config:
+            for key in self._config.keys():
+                if key.startswith(prefix):
+                    res.append(key)
+        return res
+
+    def dump_config(self):
+        for k in self.getall():
+            logging.debug(f"{k} = {self._config.get(k)}")
+

--- a/nuvolaris/user_handlers.py
+++ b/nuvolaris/user_handlers.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Provides extra kopf handlers to manage nuvolaris users
+import kopf
+import logging
+import json, flatdict, os, os.path
+import nuvolaris.config as cfg
+import nuvolaris.couchdb as cdb
+
+@kopf.on.create('nuvolaris.org', 'v1', 'whisksusers')
+def whisk_user_create(spec, name, **kwargs):
+    logging.info(f"*** whisk_user_create {name}")
+    state = {
+    }
+
+    if(spec['namespace'] and spec['password']):
+        res = cdb.create_ow_user(spec['namespace'],spec['password'])
+        logging.info(f"OpenWhisk subject {spec['namespace']} added = {res}")
+        state['couchdb']= res
+
+    return state
+
+@kopf.on.delete('nuvolaris.org', 'v1', 'whisksusers')
+def whisk_user_delete(spec, name, **kwargs):
+    logging.info(f"*** whisk_user_delete {name}")
+
+    if(spec['namespace']):
+        res = cdb.delete_ow_user(spec['namespace'])
+        logging.info(f"OpenWhisk subject {spec['namespace']} removed = {res}")
+
+@kopf.on.update('nuvolaris.org', 'v1', 'whisksusers')
+def whisk_user_update(spec, status, namespace, diff, name, **kwargs):
+    logging.info(f"*** detected an update of wsku/{name} under namespace {namespace}")

--- a/nuvolaris/user_handlers.py
+++ b/nuvolaris/user_handlers.py
@@ -21,6 +21,12 @@ import logging
 import json, flatdict, os, os.path
 import nuvolaris.config as cfg
 import nuvolaris.couchdb as cdb
+import nuvolaris.user_config as user_config
+
+def get_ucfg(spec):
+    ucfg = user_config.UserConfig(spec)
+    ucfg.dump_config()
+    return ucfg
 
 @kopf.on.create('nuvolaris.org', 'v1', 'whisksusers')
 def whisk_user_create(spec, name, **kwargs):
@@ -28,9 +34,11 @@ def whisk_user_create(spec, name, **kwargs):
     state = {
     }
 
-    if(spec['namespace'] and spec['password']):
-        res = cdb.create_ow_user(spec['namespace'],spec['password'])
-        logging.info(f"OpenWhisk subject {spec['namespace']} added = {res}")
+    ucfg = get_ucfg(spec)
+
+    if(ucfg.get("namespace") and ucfg.get("password")):
+        res = cdb.create_ow_user(ucfg.get("namespace"),ucfg.get("password"))
+        logging.info(f"OpenWhisk subject {ucfg.get('namespace')} added = {res}")
         state['couchdb']= res
 
     return state
@@ -39,9 +47,11 @@ def whisk_user_create(spec, name, **kwargs):
 def whisk_user_delete(spec, name, **kwargs):
     logging.info(f"*** whisk_user_delete {name}")
 
-    if(spec['namespace']):
-        res = cdb.delete_ow_user(spec['namespace'])
-        logging.info(f"OpenWhisk subject {spec['namespace']} removed = {res}")
+    ucfg = get_ucfg(spec)
+
+    if(ucfg.get("namespace")):
+        res = cdb.delete_ow_user(ucfg.get("namespace"))
+        logging.info(f"OpenWhisk subject {ucfg.get('namespace')} removed = {res}")
 
 @kopf.on.update('nuvolaris.org', 'v1', 'whisksusers')
 def whisk_user_update(spec, status, namespace, diff, name, **kwargs):

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -18,7 +18,7 @@
 # this module wraps utilities functions
 import nuvolaris.kube as kube
 import logging
-import time, random, math
+import time, random, math, os
 import nuvolaris.config as cfg
 import uuid
 
@@ -178,4 +178,4 @@ def check(f, what, res):
         return res and True
     else:
         logging.warn(f"ERR: {what}")
-        return False         
+        return False                    

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -178,4 +178,15 @@ def check(f, what, res):
         return res and True
     else:
         logging.warn(f"ERR: {what}")
-        return False                    
+        return False
+
+# return redis configuration parameter with default valued if not configured
+def get_redis_config_data():
+    data = {
+        "name": "redis",
+        "dir": "/redis-master-data",
+        "size": cfg.get("couchdb.volume-size", "REDIS_VOLUME_SIZE", 10),
+        "storageClass": cfg.get("nuvolaris.storageClass"),
+        "redis_password":cfg.get("redis.default.password") or "s0meP@ass3"
+    }
+    return data                           

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -171,3 +171,11 @@ def validate_ow_auth(auth):
     except Exception as e:
         logging.error('failed to determine authorization id and key: %s' % e)
         return False
+
+def check(f, what, res):
+    if f:
+        logging.info(f"OK: {what}")
+        return res and True
+    else:
+        logging.warn(f"ERR: {what}")
+        return False         

--- a/poetry.lock
+++ b/poetry.lock
@@ -571,6 +571,22 @@ files = [
 traitlets = "*"
 
 [[package]]
+name = "minio"
+version = "7.1.13"
+description = "MinIO Python SDK for Amazon S3 Compatible Cloud Storage"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "minio-7.1.13-py3-none-any.whl", hash = "sha256:462aebd79000d5b923b2a728352014f76292bbd81a9d00e3ed25aa6ec4dc41f2"},
+    {file = "minio-7.1.13.tar.gz", hash = "sha256:8828615a20cde82df79c5a52005252ad29bb022cde25177a4a43952a04c3222c"},
+]
+
+[package.dependencies]
+certifi = "*"
+urllib3 = "*"
+
+[[package]]
 name = "multidict"
 version = "6.0.4"
 description = "multidict implementation"
@@ -1232,4 +1248,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "e8a29ca9aed75c3ba6c5070ab36fda0e620328f1cfd8de65b5d6ac21f7eee7a5"
+content-hash = "2e2d7e2383fad371e0346116e29728f38b64688f47afe2aa289660583f6613dd"

--- a/tests/eks/whisk.yaml
+++ b/tests/eks/whisk.yaml
@@ -102,5 +102,8 @@ spec:
       triggers: 
         fires-perMinute: 999
     controller:
-      javaOpts: "-Xmx2048M"             
+      javaOpts: "-Xmx2048M"
+  redis:
+    default:
+      password: s0meP@ass3                 
 

--- a/tests/eks/whisk.yaml
+++ b/tests/eks/whisk.yaml
@@ -43,7 +43,9 @@ spec:
     # tls enabled or not
     tls: true
     # minio enabled or not
-    minio: true              
+    minio: true
+    # minio static enabled or not
+    static: true                  
   openwhisk:
     namespaces:
       whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abcfO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP

--- a/tests/generic/whisk.yaml
+++ b/tests/generic/whisk.yaml
@@ -99,4 +99,7 @@ spec:
       triggers: 
         fires-perMinute: 999
     controller:
-      javaOpts: "-Xmx2048M"               
+      javaOpts: "-Xmx2048M"
+  redis:
+    default:
+      password: s0meP@ass3                   

--- a/tests/generic/whisk.yaml
+++ b/tests/generic/whisk.yaml
@@ -46,6 +46,8 @@ spec:
     tls: false   
     # minio enabled or not
     minio: true
+    # minio static enabled or not
+    static: true    
   openwhisk:
     namespaces:
       whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abcfO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP

--- a/tests/k3s/traefik-middleware.yaml
+++ b/tests/k3s/traefik-middleware.yaml
@@ -15,16 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-apiVersion: v1
-kind: Pod
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
 metadata:
-  name: nuvolaris-operator
   namespace: nuvolaris
+  name: franztt-static-ingress-add-prefix
 spec:
-  serviceAccount: nuvolaris-operator
-  containers:
-    - name: nuvolaris-operator
-      image: ghcr.io/nuvolaris/nuvolaris-operator:latest
-      imagePullPolicy: Always
-      command: ["./run.sh"]
-      args: ["--verbose"]
+  addPrefix:
+    prefix: /franztt-web

--- a/tests/k3s/whisk-user.yaml
+++ b/tests/k3s/whisk-user.yaml
@@ -15,16 +15,29 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-apiVersion: v1
-kind: Pod
+apiVersion: nuvolaris.org/v1
+kind: WhiskUser
 metadata:
-  name: nuvolaris-operator
+  name: franztt
   namespace: nuvolaris
-spec:
-  serviceAccount: nuvolaris-operator
-  containers:
-    - name: nuvolaris-operator
-      image: ghcr.io/nuvolaris/nuvolaris-operator:latest
-      imagePullPolicy: Always
-      command: ["./run.sh"]
-      args: ["--verbose"]
+spec: 
+  email: francesco@nuvolaris.io
+  password: 51b64cd0-d765-419e-990d-d7dd30d7b68f:vPtIjR2MFMlYY7U5BY6N7TTogZXnJa8cl6ygPGnJIXOJonfA6MuNpVAdLN7m8iVc
+  namespace: franztt
+  redis:
+    enabled: true
+    prefix: franztt
+    password: fttredispwd
+  object-storage:        
+    password: vPtIjR2MFMlYY7U5BY6N7TTogZXnJa8cl6ygPGnJIXOJonfA6MuNpVAdLN7m8iVc
+    data:
+      enabled: true
+      bucket: franztt-data
+    route:
+      enabled: true
+      host: franztt.nuvolaris.org
+      bucket: franztt-web
+  mongodb:
+    enabled: true
+    database: franztt
+    password: ahfdajsfdafdasffdasdja

--- a/tests/k3s/whisk.yaml
+++ b/tests/k3s/whisk.yaml
@@ -99,5 +99,8 @@ spec:
       triggers: 
         fires-perMinute: 999
     controller:
-      javaOpts: "-Xmx2048M"             
+      javaOpts: "-Xmx2048M"
+  redis:
+    default:
+      password: s0meP@ass3                
 

--- a/tests/k3s/whisk.yaml
+++ b/tests/k3s/whisk.yaml
@@ -45,7 +45,9 @@ spec:
     # enable TLS
     tls: true
     # minio enabled or not
-    minio: true            
+    minio: true
+    # minio static enabled or not
+    static: true                
   openwhisk:
     namespaces:
       whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abcfO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP

--- a/tests/kind/config_user_test.ipy
+++ b/tests/kind/config_user_test.ipy
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import nuvolaris.user_config as user_cfg
+import nuvolaris.testutil as tu
+
+spec = tu.load_sample_user_config()
+cfg = user_cfg.UserConfig(spec)
+
+assert(cfg.get("namespace") == "ftt")

--- a/tests/kind/minio_util_test.ipy
+++ b/tests/kind/minio_util_test.ipy
@@ -40,7 +40,8 @@ assert(pod_name)
 
 minioClient = mutil.MinioClient()
 assert(minioClient.make_bucket("ftt-data"))
+assert(minioClient.make_public_bucket("ftt-web"))
 assert(minioClient.add_user("ftt","jgfkjsgcasgfjgdsafgsdkfgkaj"))
-assert(minioClient.assign_rw_bucket_policy_to_user("ftt","ftt-data"))
+assert(minioClient.assign_rw_bucket_policy_to_user("ftt",["ftt-web/*","ftt-data/*"]))
 
-#assert(minio.delete())
+assert(minio.delete())

--- a/tests/kind/minio_util_test.ipy
+++ b/tests/kind/minio_util_test.ipy
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all
+
+import nuvolaris.config as cfg
+import nuvolaris.testutil as tu
+import nuvolaris.kube as kube
+import nuvolaris.minio as minio
+import nuvolaris.couchdb as cdb
+import nuvolaris.couchdb_util as cdbu
+import nuvolaris.util as util
+import nuvolaris.minio_util as mutil
+import logging
+
+# test
+assert(cfg.configure(tu.load_sample_config()))
+assert(cfg.detect_storage()["nuvolaris.storageClass"])
+assert(minio.create())
+
+assert(cfg.put("minio.host", "localhost"))
+
+pod_name = util.get_pod_name("{.items[?(@.metadata.labels.app == 'minio')].metadata.name}")
+assert(pod_name)
+
+minioClient = mutil.MinioClient()
+assert(minioClient.make_bucket("ftt-data"))
+assert(minioClient.add_user("ftt","jgfkjsgcasgfjgdsafgsdkfgkaj"))
+assert(minioClient.assign_rw_bucket_policy_to_user("ftt","ftt-data"))
+
+#assert(minio.delete())

--- a/tests/kind/mongodb_user_test.ipy
+++ b/tests/kind/mongodb_user_test.ipy
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all
+
+import nuvolaris.config as cfg
+import nuvolaris.testutil as tu
+import nuvolaris.kube as kube
+import nuvolaris.mongodb as mdb
+import logging
+
+# test
+assert(cfg.configure(tu.load_sample_config()))
+assert(cfg.put("mongodb.useOperator", False))
+assert(mdb.create())
+while not kube.wait("pod/nuvolaris-mongodb-0", "condition=ready"): pass
+assert(kube.get("service/nuvolaris-mongodb-svc"))
+
+flavour = kube.kubectl("get", "pod/nuvolaris-mongodb-0", jsonpath="{.metadata.labels.nuvolaris\.mongodb\.flavour}")
+assert("standalone"==flavour[0])
+
+assert(mdb.create_db_user('franztt','ftt','1234567890'))
+assert(mdb.delete_db_user('franztt','ftt'))
+assert(mdb.delete())
+
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all

--- a/tests/kind/nginx_static_test.ipy
+++ b/tests/kind/nginx_static_test.ipy
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all
+
+import nuvolaris.config as cfg
+import nuvolaris.testutil as tu
+import nuvolaris.minio as minio
+import nuvolaris.util as util
+import nuvolaris.nginx_static as nginx
+import logging
+
+# test
+assert(cfg.configure(tu.load_sample_config()))
+assert(cfg.detect_storage()["nuvolaris.storageClass"])
+assert(minio.create())
+assert(nginx.create())
+
+assert(nginx.delete())
+assert(minio.delete())

--- a/tests/kind/nuvolaris_subject_test.ipy
+++ b/tests/kind/nuvolaris_subject_test.ipy
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all
+
+import nuvolaris.couchdb as cdb
+import nuvolaris.couchdb_util as cdbu
+import nuvolaris.testutil as tu
+import nuvolaris.config as cfg
+import nuvolaris.kube as kube
+import requests as req
+import time
+import subprocess
+import json
+from kopf.testing import KopfRunner
+
+assert(cfg.configure(tu.load_sample_config()))
+assert(cfg.detect_labels()["nuvolaris.kube"] == "kind")
+assert(cfg.detect_storage()["nuvolaris.storageClass"] == "standard")
+assert(cfg.put("couchdb.host", "localhost"))
+
+!kubectl apply -f tests/kind/whisk.yaml
+wsk = kube.get("wsk/controller")
+cdb.create(wsk)
+
+import nuvolaris.couchdb_util
+db = nuvolaris.couchdb_util.CouchDB()
+
+assert(db.wait_db_ready(60))
+assert(db.configure_single_node())
+assert(db.configure_no_reduce_limit())
+
+assert(cdb.init_system(db))
+assert(cdb.init_subjects(db))
+assert(cdb.init_activations(db))
+assert(cdb.init_actions(db))
+assert(cdb.add_initial_subjects(db))
+
+with KopfRunner(['run', '-A', '--verbose', 'nuvolaris/user_handlers.py']) as runner:
+    # do something while the operator is running.
+    !kubectl apply -f tests/whisk-user.yaml      
+    time.sleep(1)  # give it some time to react and to sleep and to retry
+    wsku = kube.get("wsku/ftt")    
+    assert(wsku['spec'])
+
+    !kubectl delete -f tests/whisk-user.yaml           
+    time.sleep(1)  # give it some time to react
+
+assert runner.exit_code == 0
+assert runner.exception is None
+
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all
+

--- a/tests/kind/whisk-user.yaml
+++ b/tests/kind/whisk-user.yaml
@@ -28,16 +28,16 @@ spec:
     enabled: true
     prefix: ftt
     password: fttredispwd
-  object-storage:
-    enabled: true
-    bucket: ftt-data
-    password: dsadgasdfsagdfasfda
+  object-storage:        
+    password: vPtIjR2MFMlYY7U5BY6N7TTogZXnJa8cl6ygPGnJIXOJonfA6MuNpVAdLN7m8iVc
+    data:
+      enabled: true
+      bucket: franztt-data
+    route:
+      enabled: true
+      host: localhost
+      bucket: franztt-web
   mongodb:
     enabled: true
     database: ftt
     password: ahfdajsfdafdasffdasdja
-  route:
-    enabled: true
-    host: localhost
-    bucket: ftt-web
-    password: sadgsagdsagdsagdsagdakajg

--- a/tests/kind/whisk-user.yaml
+++ b/tests/kind/whisk-user.yaml
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,8 +15,29 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-echo CONTROLLER: "$CONTROLLER_IMAGE:$CONTROLLER_TAG"
-echo OPERATOR: "$OPERATOR_IMAGE:$OPERATOR_TAG"
-
-kubectl apply -f deploy/nuvolaris-permissions/
-poetry run kopf run -n nuvolaris -m nuvolaris nuvolaris/main.py nuvolaris/user_handlers.py "$@"
+apiVersion: nuvolaris.org/v1
+kind: WhiskUser
+metadata:
+  name: franztt
+  namespace: nuvolaris
+spec: 
+  email: francesco@nuvolaris.io
+  password: 51b64cd0-d765-419e-990d-d7dd30d7b68f:vPtIjR2MFMlYY7U5BY6N7TTogZXnJa8cl6ygPGnJIXOJonfA6MuNpVAdLN7m8iVc
+  namespace: franztt
+  redis:
+    enabled: true
+    prefix: ftt
+    password: fttredispwd
+  object-storage:
+    enabled: true
+    bucket: ftt-data
+    password: dsadgasdfsagdfasfda
+  mongodb:
+    enabled: true
+    database: ftt
+    password: ahfdajsfdafdasffdasdja
+  route:
+    enabled: true
+    host: localhost
+    bucket: ftt-web
+    password: sadgsagdsagdsagdsagdakajg

--- a/tests/kind/whisk.yaml
+++ b/tests/kind/whisk.yaml
@@ -100,3 +100,6 @@ spec:
         fires-perMinute: 999
     controller:
       javaOpts: "-Xmx2048M"
+  redis:
+    default:
+      password: s0meP@ass3

--- a/tests/kind/whisk.yaml
+++ b/tests/kind/whisk.yaml
@@ -41,7 +41,9 @@ spec:
     # tls enabled or not
     tls: false
     # minio enabled or not
-    minio: true    
+    minio: true 
+    # minio static enabled or not
+    static: true        
   openwhisk:
     namespaces:
       whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP

--- a/tests/lks/whisk.yaml
+++ b/tests/lks/whisk.yaml
@@ -100,5 +100,8 @@ spec:
       triggers: 
         fires-perMinute: 999
     controller:
-      javaOpts: "-Xmx2048M"          
+      javaOpts: "-Xmx2048M"
+  redis:
+    default:
+      password: s0meP@ass3               
 

--- a/tests/lks/whisk.yaml
+++ b/tests/lks/whisk.yaml
@@ -47,6 +47,8 @@ spec:
     tls: true
     # minio enabled or not
     minio: true
+    # minio static enabled or not
+    static: true     
   openwhisk:
     namespaces:
       whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abcfO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP

--- a/tests/microk8s/whisk-user.yaml
+++ b/tests/microk8s/whisk-user.yaml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: nuvolaris.org/v1
+kind: WhiskUser
+metadata:
+  name: franztt
+  namespace: nuvolaris
+spec: 
+  email: francesco@nuvolaris.io
+  password: 51b64cd0-d765-419e-990d-d7dd30d7b68f:vPtIjR2MFMlYY7U5BY6N7TTogZXnJa8cl6ygPGnJIXOJonfA6MuNpVAdLN7m8iVc
+  namespace: franztt
+  redis:
+    enabled: true
+    prefix: franztt
+    password: fttredispwd
+  object-storage:        
+    password: vPtIjR2MFMlYY7U5BY6N7TTogZXnJa8cl6ygPGnJIXOJonfA6MuNpVAdLN7m8iVc
+    data:
+      enabled: true
+      bucket: franztt-data
+    route:
+      enabled: true
+      host: franztt.44.203.144.96.nip.io
+      bucket: franztt-web
+  mongodb:
+    enabled: true
+    database: franztt
+    password: ahfdajsfdafdasffdasdja

--- a/tests/microk8s/whisk.yaml
+++ b/tests/microk8s/whisk.yaml
@@ -45,7 +45,9 @@ spec:
     # enable TLS
     tls: true
     # minio enabled or not
-    minio: true    
+    minio: true
+    # minio static enabled or not
+    static: true        
   openwhisk:
     namespaces:
       whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abcfO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP

--- a/tests/microk8s/whisk.yaml
+++ b/tests/microk8s/whisk.yaml
@@ -100,5 +100,8 @@ spec:
       triggers: 
         fires-perMinute: 999
     controller:
-      javaOpts: "-Xmx2048M"         
+      javaOpts: "-Xmx2048M"
+  redis:
+    default:
+      password: s0meP@ass3               
 

--- a/tests/mongodb_add_user_script.js
+++ b/tests/mongodb_add_user_script.js
@@ -1,0 +1,11 @@
+db = db.getSiblingDB('franztt');
+
+db.createUser({
+    user: "franztt",
+    pwd: "dadadasdaasgdadgagdadakj",
+    roles: [
+        {role: "readWrite", db: "franztt"}
+    ]
+});
+
+db.nuv_test_collection.insertOne({"message":"Welcome to nuvolaris!"})

--- a/tests/redis_user_test.ipy
+++ b/tests/redis_user_test.ipy
@@ -1,0 +1,47 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import nuvolaris.testutil as tu
+import nuvolaris.config as cfg
+import nuvolaris.kustomize as kus
+import nuvolaris.kube as kube
+import nuvolaris.redis as redis
+
+import requests as req
+import yaml, sys, os
+
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all
+
+cfg.clean()
+cfg.detect_labels()
+cfg.detect_storage()
+
+assert(redis.create())
+while not kube.wait("po/redis-0", "condition=ready"): pass
+assert(kube.get("po/redis-0"))
+assert(kube.get("svc/redis"))
+
+assert(redis.create_db_user('franztt','ftt','hjdgfkjdgfkdsgfkjhdsgfkgfadksjfgdkfgsdakfgdskgk'))
+
+#assert(redis.delete_db_user('franztt'))
+#assert(redis.delete())
+
+#!kubectl -n nuvolaris delete all --all
+#!kubectl -n nuvolaris delete pvc --all

--- a/tests/whisk-user.yaml
+++ b/tests/whisk-user.yaml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: nuvolaris.org/v1
+kind: WhiskUser
+metadata:
+  name: ftt
+  namespace: nuvolaris
+spec: 
+  email: francesco@nuvolaris.io
+  password: 51b64cd0-d765-419e-990d-d7dd30d7b68f:vPtIjR2MFMlYY7U5BY6N7TTogZXnJa8cl6ygPGnJIXOJonfA6MuNpVAdLN7m8iVc
+  namespace: ftt
+  redis:
+    enabled: false
+    prefix: ftt
+    password: fttredispwd
+  object-storage:
+    enabled: false
+    bucket: ftt-data
+    password: dsadgasdfsagdfasfda
+  mongodb:
+    enabled: false
+    database: ftt
+    password: ahfdajsfdafdasffdasdja
+  route:
+    enabled: false
+    host: localhost
+    bucket: ftt-web
+    password: sadgsagdsagdsagdsagdakajg

--- a/tests/whisk-user.yaml
+++ b/tests/whisk-user.yaml
@@ -18,26 +18,26 @@
 apiVersion: nuvolaris.org/v1
 kind: WhiskUser
 metadata:
-  name: ftt
+  name: franztt
   namespace: nuvolaris
 spec: 
   email: francesco@nuvolaris.io
   password: 51b64cd0-d765-419e-990d-d7dd30d7b68f:vPtIjR2MFMlYY7U5BY6N7TTogZXnJa8cl6ygPGnJIXOJonfA6MuNpVAdLN7m8iVc
-  namespace: ftt
+  namespace: franztt
   redis:
     enabled: false
     prefix: ftt
     password: fttredispwd
-  object-storage:
-    enabled: false
-    bucket: ftt-data
+  object-storage:        
     password: dsadgasdfsagdfasfda
+    data:
+      enabled: false
+      bucket: ftt-data
+    route:
+      enabled: false
+      host: localhost
+      bucket: ftt-web
   mongodb:
     enabled: false
     database: ftt
     password: ahfdajsfdafdasffdasdja
-  route:
-    enabled: false
-    host: localhost
-    bucket: ftt-web
-    password: sadgsagdsagdsagdsagdakajg

--- a/tests/whisk.yaml
+++ b/tests/whisk.yaml
@@ -96,5 +96,8 @@ spec:
       triggers: 
         fires-perMinute: 999
     controller:
-      javaOpts: "-Xmx2048M"      
+      javaOpts: "-Xmx2048M"
+  redis:
+    default:
+      password: s0meP@ass3            
 


### PR DESCRIPTION
Implements basic functionalities to support a  whisk-user.yaml deployments with a structure similar to this one here

```
spec:
    email: <email>
    password: <password>
    namespace: <namespace>
    redis:
       enabled: <flag>
       prefix: <prefix>
       password: <redis-password>
    object-storage:
       password: <adasas>
       data:
        enabled: <flag>
        bucket: <bucket>
       route: 
         enabled: <flag>
         host: <hostname>
         bucket: <bucket>
    mongodb:
        enabled: <flag>
        database: <database> 
        password: <mongodb-password>
```

- creates/removes a new OW subject for the specified `namespace`
- creates/removes MINIO buckets named `object.storage.data.bucket` and `object.storage.route.bucket` and adds a <namespace> user with RW privileges on the created buckets. In addition the `object.storage.route.bucket` is marked to be publicly available. 
- deploys an NGINX service to expose MINIO static content
- configure an NGINX ingress per user(/namespace) exposing the bucket `object.storage.route.bucket` content using hostname `object.storage.route.host`
- configures mongodb database for the given user
- configures redis user with ACL limiting access (GET,SET,DEL) key starting with `prefix:`