### PR TITLE
fix: updated mc client download URL used for operator image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN rm -Rvf /tmp/minio-binaries ;\
     MINIO_BASE=https://dl.min.io/client/mc/release/linux ;\
     ARCH=$(dpkg --print-architecture) ;\
     MC_VER=RELEASE.2023-03-23T20-03-04Z ;\
-    MINIO_URL="$MINIO_BASE-$ARCH/mc.${MC_VER}" ;\
+    MINIO_URL="$MINIO_BASE-$ARCH/archive/mc.${MC_VER}" ;\
     curl -sL "$MINIO_URL" --create-dirs -o /tmp/minio-binaries/mc ;\
     chmod +x /tmp/minio-binaries/mc ;\
     mv /tmp/minio-binaries/mc /usr/bin/mc ;\


### PR DESCRIPTION
To give stability to MINIO setup the operator uses the mc client version as per configured MINIO server version, had to update the download URL to use the archive URL as mc builds are moved once new version is out.