### PR TITLE
Implements nuvolaris/nuvolaris#197

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ whisk.properties
 .task/
 *.log
 .latestcheck
+_failed.txt

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -204,6 +204,8 @@ tasks:
         ignore_error: true
       - cmd: kubectl -n nuvolaris delete ing --all --grace-period=0
         ignore_error: true
+      - cmd: kubectl -n nuvolaris delete cm/config --grace-period=0
+        ignore_error: true        
 
   utest:
     cmds:

--- a/deploy/mongodb-standalone/mongodb-svc.yaml
+++ b/deploy/mongodb-standalone/mongodb-svc.yaml
@@ -27,5 +27,5 @@ spec:
     - port: 27017
       targetPort: 27017
   selector:
-    app: nuvolaris-mongodb
+    app: nuvolaris-mongodb-svc
     statefulset.kubernetes.io/pod-name: nuvolaris-mongodb-0

--- a/deploy/nuvolaris-permissions/whisk-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-crd.yaml
@@ -267,19 +267,31 @@ spec:
                     volume-size:
                       description: volume size in GB
                       type: integer
-                    nuvolaris:
-                      description: used to configure the MINIO root admin user used by nuvolaris itself
+                    admin:
+                      description: used to configure the MINIO admin user
                       type: object
                       properties:
-                        root-user:
+                        user:
                           type: string
-                        root-password:
+                        password:
                           type: string
                       required:
-                      - root-user
-                      - root-password
+                      - user
+                      - password
+                    nuvolaris:
+                      description: used to configure the MINIO nuvolaris user used for non administrative purposes
+                      type: object
+                      properties:
+                        user:
+                          type: string
+                        password:
+                          type: string
+                      required:
+                      - user
+                      - password
                   required:
                   - volume-size
+                  - admin
                   - nuvolaris 
                 redis:
                   description: used to configure redis default credentials
@@ -289,15 +301,28 @@ spec:
                       description: redis volume size in GB 
                       type: integer
                     default:
+                      description: used to configure REDIS default admin credentials
                       type: object
                       properties:
                         password:
                           type: string
                       required:
                       - password
+                    nuvolaris:
+                      description: used to configure nuvolaris REDIS user
+                      type: object
+                      properties:
+                        prefix:
+                          description: nuvolaris key prefix. Defaulted to nuv
+                          type: string
+                        password:
+                          type: string
+                      required:
+                      - password                      
                   required:
                   - volume-size
                   - default
+                  - nuvolaris
                 configs:
                   description: Configuration parameters to customize OW controller/invoker
                   type: object

--- a/nuvolaris/minio.py
+++ b/nuvolaris/minio.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import kopf, logging, json, os
+import kopf, logging, time, os
 import nuvolaris.kube as kube
 import nuvolaris.kustomize as kus
 import nuvolaris.config as cfg
@@ -105,6 +105,8 @@ def create_nuv_storage(data):
     Creates nuvolaris MINIO custom resources
     """
     logging.info(f"*** configuring MINIO storage for nuvolaris")
+    # introduce a 10 seconds delay to be sure that MINIO server is up and running completely as pod readines seems to be no enough
+    time.sleep(10)
     minioClient = mutil.MinioClient()
     res = minioClient.add_user(data["minio_nuv_user"], data["minio_nuv_password"])
     

--- a/nuvolaris/minio.py
+++ b/nuvolaris/minio.py
@@ -105,7 +105,7 @@ def create_nuv_storage(data):
     Creates nuvolaris MINIO custom resources
     """
     logging.info(f"*** configuring MINIO storage for nuvolaris")
-    # introduce a 10 seconds delay to be sure that MINIO server is up and running completely as pod readines seems to be no enough
+    # introduce a 10 seconds delay to be sure that MINIO server is up and running completely as pod readines not to be enough
     time.sleep(10)
     minioClient = mutil.MinioClient()
     res = minioClient.add_user(data["minio_nuv_user"], data["minio_nuv_password"])

--- a/nuvolaris/minio.py
+++ b/nuvolaris/minio.py
@@ -21,6 +21,7 @@ import nuvolaris.kustomize as kus
 import nuvolaris.config as cfg
 import nuvolaris.util as util
 import nuvolaris.minio_util as mutil
+import nuvolaris.openwhisk as openwhisk
 
 from nuvolaris.user_config import UserConfig
 from nuvolaris.user_metadata import UserMetadata
@@ -43,13 +44,13 @@ def _add_miniouser_metadata(ucfg: UserConfig, user_metadata:UserMetadata):
 
             ports = list(minio_service['spec']['ports'])
             for port in ports:
-                if(port[name]=='minio-api'):
+                if(port['name']=='minio-api'):
                     user_metadata.add_metadata("MINIO_PORT",port['port'])
         return None
     except Exception as e:
         logging.error(f"failed to build redis_url for {ucfg.get('namespace')}: {e}")
         return None 
-
+    
 def find_content_path(filename):
     absolute_path = os.path.dirname(__file__)
     relative_path = "../deploy/content"
@@ -58,14 +59,7 @@ def find_content_path(filename):
 def create(owner=None):
     logging.info(f"*** configuring minio standalone")
 
-    data = {
-        "minio_host": cfg.get('minio.host') or "minio",
-        "minio_volume_size": cfg.get('minio.volume-size') or "5",
-        "minio_root_user": cfg.get('minio.nuvolaris.root-user') or "minio",
-        "minio_root_password": cfg.get('minio.nuvolaris.root-password') or "minio123",
-        "storage_class": cfg.get("nuvolaris.storageClass")
-    }
-    
+    data = util.get_minio_config_data()    
     kust = kus.patchTemplates("minio", ["00-minio-pvc.yaml","01-minio-dep.yaml","02-minio-svc.yaml"], data)    
     spec = kus.kustom_list("minio", kust, templates=[], data=data)
 
@@ -78,9 +72,72 @@ def create(owner=None):
 
     # dynamically detect minio pod and wait for readiness
     util.wait_for_pod_ready("{.items[?(@.metadata.labels.app == 'minio')].metadata.name}")
-
+    create_nuv_storage(data)
     logging.info("*** configured minio standalone")
     return res
+
+def _annotate_nuv_metadata(data):
+    """
+    annotate nuvolaris confgimap with entries for minio connectivity MINIO_ENDPOINT, MINIO_PORT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY
+    this is becasue MINIO
+    """ 
+    try:
+        minio_service =  util.get_service("{.items[?(@.spec.selector.app == 'minio')]}")
+        if(minio_service):
+            minio_endpoint = f"{minio_service['metadata']['name']}.{minio_service['metadata']['namespace']}.svc.cluster.local"
+            access_key = data["minio_nuv_user"]
+            secret_key = data["minio_nuv_password"]
+            openwhisk.annotate(f"minio_url={minio_endpoint}")
+            openwhisk.annotate(f"minio_access_key={access_key}")
+            openwhisk.annotate(f"minio_secret_key={secret_key}")
+
+            ports = list(minio_service['spec']['ports'])
+            for port in ports:
+                if(port['name']=='minio-api'):
+                    openwhisk.annotate(f"minio_port={port['port']}")                    
+        return None
+    except Exception as e:
+        logging.error(f"failed to build redis_url for nuvolaris: {e}")
+        return None      
+
+def create_nuv_storage(data):
+    """
+    Creates nuvolaris MINIO custom resources
+    """
+    logging.info(f"*** configuring MINIO storage for nuvolaris")
+    minioClient = mutil.MinioClient()
+    res = minioClient.add_user(data["minio_nuv_user"], data["minio_nuv_password"])
+    
+    if(res):
+        _annotate_nuv_metadata(data)
+        bucket_policy_names = []
+
+        logging.info(f"*** adding nuvolaris MINIO data bucket")
+        res = minioClient.make_bucket("nuvolaris-data")                
+        bucket_policy_names.append("nuvolaris-data/*")
+
+        if(res):
+            openwhisk.annotate(f"nuvolaris_minio_data_bucket=nuvolaris-data")
+
+        logging.info(f"*** adding nuvolaris MINIO static bucket")
+        res = minioClient.make_bucket("nuvolaris-web")                
+        bucket_policy_names.append("nuvolaris-web/*")
+
+        if(res):
+            openwhisk.annotate(f"nuvolaris_minio_static_bucket=nuvolaris-web")
+            content_path = find_content_path("index.html")
+
+            if(content_path):
+                logging.info(f"uploading example content to nuvolaris-web from {content_path}")
+                res = minioClient.upload_folder_content(content_path,"nuvolaris-web")
+            else:
+                logging.warn("could not find example static content to upload")
+
+        if(len(bucket_policy_names)>0):
+            logging.info(f"granting rw access to created policies under username {data['minio_nuv_user']}")
+            minioClient.assign_rw_bucket_policy_to_user(data["minio_nuv_user"],bucket_policy_names)
+
+        logging.info(f"*** configured MINIO storage for nuvolaris") 
 
 def delete():
     spec = cfg.get("state.minio.spec")
@@ -91,8 +148,7 @@ def delete():
     return res
 
 def create_ow_storage(state, ucfg: UserConfig, user_metadata: UserMetadata, owner=None):
-    minioClient = mutil.MinioClient()
-    
+    minioClient = mutil.MinioClient()    
     namespace = ucfg.get("namespace")
     secretkey = ucfg.get("object-storage.password")
 

--- a/nuvolaris/minio_util.py
+++ b/nuvolaris/minio_util.py
@@ -31,8 +31,8 @@ class MinioClient:
     def __init__(self):
         self.minio_api_host   = cfg.get("minio.host", "MINIO_API_HOST", "minio")
         self.minio_api_port   = cfg.get("9000", "MINIO_API_PORT", "9000")        
-        self.admin_username   = cfg.get("minio.nuvolaris.root-user", "MINIO_ADMIN_USER", "minio")
-        self.admin_password   = cfg.get("minio.nuvolaris.root-password", "MINIO_ADMIN_PASSWORD", "minio123")
+        self.admin_username   = cfg.get("minio.admin.user", "MINIO_ADMIN_USER", "minioadmin")
+        self.admin_password   = cfg.get("minio.admin.password", "MINIO_ADMIN_PASSWORD", "minioadmin")
         self.minio_api_url   = f"http://{self.minio_api_host}:{self.minio_api_port}"
         self.alias = "local"        
 

--- a/nuvolaris/mongodb_operator.py
+++ b/nuvolaris/mongodb_operator.py
@@ -99,8 +99,9 @@ def create(owner=None):
         else:
             cfg.put("state.mongodb.spec", mspec)
         
-        # skipping this at the moment
         res = kube.apply(mspec)
+        # dynamically detect mongodb pod and wait for readiness
+        util.wait_for_pod_ready("{.items[?(@.metadata.labels.app == 'nuvolaris-mongodb-svc')].metadata.name}")
     else:
         logging.info("*** something went wrong deploying mongodb operator")    
     return res 

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -180,14 +180,17 @@ def check(f, what, res):
         logging.warn(f"ERR: {what}")
         return False
 
-# return redis configuration parameter with default valued if not configured
+# return redis configuration parameters with default values if not configured
 def get_redis_config_data():
     data = {
         "name": "redis",
         "dir": "/redis-master-data",
         "size": cfg.get("redis.volume-size", "REDIS_VOLUME_SIZE", 10),
         "storageClass": cfg.get("nuvolaris.storageClass"),
-        "redis_password":cfg.get("redis.default.password") or "s0meP@ass3"
+        "redis_password":cfg.get("redis.default.password") or "s0meP@ass3",
+        "namespace":"nuvolaris",
+        "password":cfg.get("redis.nuvolaris.password") or "s0meP@ass3",
+        "prefix":cfg.get("redis.nuvolaris.prefix") or "nuv"
     }
     return data
 
@@ -196,4 +199,17 @@ def get_service(jsonpath,namespace="nuvolaris"):
     if(services):
         return services[0]
 
-    raise Exception(f"could not find any svc matching jsonpath={jsonpath}")                                
+    raise Exception(f"could not find any svc matching jsonpath={jsonpath}")
+
+# return minio configuration parameters with default values if not configured
+def get_minio_config_data():
+    data = {
+        "minio_host": cfg.get('minio.host') or "minio",
+        "minio_volume_size": cfg.get('minio.volume-size') or "5",
+        "minio_root_user": cfg.get('minio.admin.user') or "minio",
+        "minio_root_password": cfg.get('minio.admin.password') or "minio123",
+        "storage_class": cfg.get("nuvolaris.storageClass"),
+        "minio_nuv_user": cfg.get('minio.nuvolaris.user') or "nuvolaris",
+        "minio_nuv_password": cfg.get('minio.nuvolaris.password') or "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+    }
+    return data                               

--- a/tests/eks/whisk.yaml
+++ b/tests/eks/whisk.yaml
@@ -60,17 +60,7 @@ spec:
       password: s0meP@ass1
     invoker:
       user: controller_admin
-      password: s0meP@ass2
-  mongodb:
-    host: mongodb
-    volume-size: 10
-    admin: 
-      user: whisk_admin
-      password: 0therPa55
-    nuvolaris:
-      user: nuvolaris
-      password: s0meP@ass3
-    useOperator: False  
+      password: s0meP@ass2  
   kafka:
     host: kafka
     volume-size: 10
@@ -79,11 +69,6 @@ spec:
   tls:
     acme-registered-email: francesco@nuvolaris.io
     acme-server-url: https://acme-v02.api.letsencrypt.org/directory
-  minio:
-    volume-size: 2
-    nuvolaris:
-      root-user: minioadmin
-      root-password: minioadmin
   configs:
     limits:
       actions:
@@ -94,8 +79,30 @@ spec:
         fires-perMinute: 999
     controller:
       javaOpts: "-Xmx2048M"
-  redis:  
-    volume-size: 10  
+  redis:
+    volume-size: 10
     default:
-      password: s0meP@ass3                 
+      password: s0meP@ass3
+    nuvolaris:
+      prefix: nuv      
+      password: s0meP@ass3
+  mongodb:
+    host: mongodb
+    volume-size: 10
+    admin: 
+      user: whisk_admin
+      password: 0therPa55
+    nuvolaris:
+      user: nuvolaris
+      password: s0meP@ass3
+    exposedExternally: False
+    useOperator: False
+  minio:
+    volume-size: 2
+    admin:
+      user: minioadmin
+      password: minioadmin    
+    nuvolaris:
+      user: nuvolaris
+      password: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG                 
 

--- a/tests/generic/whisk.yaml
+++ b/tests/generic/whisk.yaml
@@ -63,15 +63,6 @@ spec:
     invoker:
       user: controller_admin
       password: s0meP@ass2
-  mongodb:
-    host: mongodb
-    volume-size: 10
-    admin: 
-      user: whisk_admin
-      password: 0therPa55
-    nuvolaris:
-      user: nuvolaris
-      password: s0meP@ass3
   kafka:
     host: kafka
     volume-size: 10
@@ -80,11 +71,6 @@ spec:
   tls:
     acme-registered-email: francesco@nuvolaris.io
     acme-server-url: https://acme-staging-v02.api.letsencrypt.org/directory
-  minio:
-    volume-size: 2
-    nuvolaris:
-      root-user: minioadmin
-      root-password: minioadmin
   configs:
     limits:
       actions:
@@ -98,4 +84,26 @@ spec:
   redis:
     volume-size: 10
     default:
-      password: s0meP@ass3                   
+      password: s0meP@ass3
+    nuvolaris:
+      prefix: nuv      
+      password: s0meP@ass3
+  mongodb:
+    host: mongodb
+    volume-size: 10
+    admin: 
+      user: whisk_admin
+      password: 0therPa55
+    nuvolaris:
+      user: nuvolaris
+      password: s0meP@ass3
+    exposedExternally: False
+    useOperator: False
+  minio:
+    volume-size: 2
+    admin:
+      user: minioadmin
+      password: minioadmin    
+    nuvolaris:
+      user: nuvolaris
+      password: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG                  

--- a/tests/k3s/whisk.yaml
+++ b/tests/k3s/whisk.yaml
@@ -61,15 +61,6 @@ spec:
     invoker:
       user: controller_admin
       password: s0meP@ass2
-  mongodb:
-    host: mongodb
-    volume-size: 10
-    admin: 
-      user: whisk_admin
-      password: 0therPa55
-    nuvolaris:
-      user: nuvolaris
-      password: s0meP@ass3
   kafka:
     host: kafka
     volume-size: 10
@@ -78,11 +69,6 @@ spec:
   tls:
     acme-registered-email: francesco@nuvolaris.io
     acme-server-url: https://acme-v02.api.letsencrypt.org/directory
-  minio:
-    volume-size: 2
-    nuvolaris:
-      root-user: minioadmin
-      root-password: minioadmin 
   configs:
     limits:
       actions:
@@ -96,5 +82,27 @@ spec:
   redis:
     volume-size: 10
     default:
-      password: s0meP@ass3                
+      password: s0meP@ass3
+    nuvolaris:
+      prefix: nuv      
+      password: s0meP@ass3
+  mongodb:
+    host: mongodb
+    volume-size: 10
+    admin: 
+      user: whisk_admin
+      password: 0therPa55
+    nuvolaris:
+      user: nuvolaris
+      password: s0meP@ass3
+    exposedExternally: False
+    useOperator: False
+  minio:
+    volume-size: 2
+    admin:
+      user: minioadmin
+      password: minioadmin    
+    nuvolaris:
+      user: nuvolaris
+      password: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG                
 

--- a/tests/kind/minio_static_test.ipy
+++ b/tests/kind/minio_static_test.ipy
@@ -24,10 +24,15 @@ import nuvolaris.minio as minio
 import nuvolaris.util as util
 import nuvolaris.minio_static as nginx
 import logging
+import os
 
 # test
 assert(cfg.configure(tu.load_sample_config()))
 assert(cfg.detect_storage()["nuvolaris.storageClass"])
+
+# for this test minioClient should see this env variable
+os.environ['MINIO_API_HOST']='localhost'
+
 assert(minio.create())
 assert(nginx.create())
 

--- a/tests/kind/minio_test.ipy
+++ b/tests/kind/minio_test.ipy
@@ -25,18 +25,24 @@ import nuvolaris.minio as minio
 import nuvolaris.couchdb as cdb
 import nuvolaris.couchdb_util as cdbu
 import nuvolaris.util as util
-import logging
+import logging, os
 
 # test
 assert(cfg.configure(tu.load_sample_config()))
 assert(cfg.detect_storage()["nuvolaris.storageClass"])
+
+# for this test minioClient should see this env variable
+os.environ['MINIO_API_HOST']='localhost'
+
 assert(minio.create())
 
 pod_name = util.get_pod_name("{.items[?(@.metadata.labels.app == 'minio')].metadata.name}")
 assert(pod_name)
 
 actual_minio_root_user = kube.kubectl("get", f"pods/{pod_name}", jsonpath="{.spec.containers[0].env[0].value}")
-configured_minio_root_user = cfg.get('minio.nuvolaris.root-user')
+configured_minio_root_user = cfg.get('minio.admin.user')
 assert(actual_minio_root_user[0] == configured_minio_root_user)
 
+cm_minio_url = kube.kubectl("get", f"cm/config", jsonpath="{.metadata.annotations.minio_url}")
+assert(cm_minio_url)
 assert(minio.delete())

--- a/tests/kind/minio_util_test.ipy
+++ b/tests/kind/minio_util_test.ipy
@@ -26,14 +26,14 @@ import nuvolaris.couchdb as cdb
 import nuvolaris.couchdb_util as cdbu
 import nuvolaris.util as util
 import nuvolaris.minio_util as mutil
-import logging
+import logging, os
 
 # test
 assert(cfg.configure(tu.load_sample_config()))
 assert(cfg.detect_storage()["nuvolaris.storageClass"])
-assert(minio.create())
 
-assert(cfg.put("minio.host", "localhost"))
+os.environ['MINIO_API_HOST']='localhost'
+assert(minio.create())
 
 pod_name = util.get_pod_name("{.items[?(@.metadata.labels.app == 'minio')].metadata.name}")
 assert(pod_name)

--- a/tests/kind/mongodb_op_test.ipy
+++ b/tests/kind/mongodb_op_test.ipy
@@ -36,5 +36,5 @@ assert(kube.get("mdbc/nuvolaris-mongodb"))
 
 assert(mdb.delete())
 
-!kubectl -n nuvolaris delete all --all
-!kubectl -n nuvolaris delete pvc --all
+#!kubectl -n nuvolaris delete all --all
+#!kubectl -n nuvolaris delete pvc --all

--- a/tests/kind/whisk.yaml
+++ b/tests/kind/whisk.yaml
@@ -59,17 +59,6 @@ spec:
     invoker:
       user: controller_admin
       password: s0meP@ass2
-  mongodb:
-    host: mongodb
-    volume-size: 10
-    admin: 
-      user: whisk_admin
-      password: 0therPa55
-    nuvolaris:
-      user: nuvolaris
-      password: s0meP@ass3
-    exposedExternally: False
-    useOperator: False
   kafka:
     host: kafka
     volume-size: 10
@@ -78,11 +67,6 @@ spec:
   tls:
     acme-registered-email: francesco@nuvolaris.io
     acme-server-url: https://acme-staging-v02.api.letsencrypt.org/directory
-  minio:
-    volume-size: 2
-    nuvolaris:
-      root-user: minioadmin
-      root-password: minioadmin
   configs:
     limits:
       actions:
@@ -97,3 +81,25 @@ spec:
     volume-size: 10
     default:
       password: s0meP@ass3
+    nuvolaris:
+      prefix: nuv      
+      password: s0meP@ass3
+  mongodb:
+    host: mongodb
+    volume-size: 10
+    admin: 
+      user: whisk_admin
+      password: 0therPa55
+    nuvolaris:
+      user: nuvolaris
+      password: s0meP@ass3
+    exposedExternally: False
+    useOperator: False
+  minio:
+    volume-size: 2
+    admin:
+      user: minioadmin
+      password: minioadmin    
+    nuvolaris:
+      user: nuvolaris
+      password: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG              

--- a/tests/lks/whisk.yaml
+++ b/tests/lks/whisk.yaml
@@ -64,15 +64,6 @@ spec:
     invoker:
       user: controller_admin
       password: s0meP@ass2
-  mongodb:
-    host: mongodb
-    volume-size: 10
-    admin: 
-      user: whisk_admin
-      password: 0therPa55
-    nuvolaris:
-      user: nuvolaris
-      password: s0meP@ass3
   kafka:
     host: kafka
     volume-size: 10
@@ -81,11 +72,6 @@ spec:
   tls:
     acme-registered-email: francesco@nuvolaris.io
     acme-server-url: https://acme-v02.api.letsencrypt.org/directory  
-  minio:
-    volume-size: 2
-    nuvolaris:
-      root-user: minioadmin
-      root-password: minioadmin
   configs:
     limits:
       actions:
@@ -99,5 +85,27 @@ spec:
   redis:
     volume-size: 10
     default:
-      password: s0meP@ass3               
+      password: s0meP@ass3
+    nuvolaris:
+      prefix: nuv      
+      password: s0meP@ass3
+  mongodb:
+    host: mongodb
+    volume-size: 10
+    admin: 
+      user: whisk_admin
+      password: 0therPa55
+    nuvolaris:
+      user: nuvolaris
+      password: s0meP@ass3
+    exposedExternally: False
+    useOperator: False
+  minio:
+    volume-size: 2
+    admin:
+      user: minioadmin
+      password: minioadmin    
+    nuvolaris:
+      user: nuvolaris
+      password: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG               
 

--- a/tests/microk8s/whisk.yaml
+++ b/tests/microk8s/whisk.yaml
@@ -61,16 +61,6 @@ spec:
     invoker:
       user: controller_admin
       password: s0meP@ass2
-  mongodb:
-    host: mongodb
-    volume-size: 10
-    admin: 
-      user: whisk_admin
-      password: 0therPa55
-    nuvolaris:
-      user: nuvolaris
-      password: s0meP@ass3
-    useOperator: False
   kafka:
     host: kafka
     volume-size: 10
@@ -79,11 +69,6 @@ spec:
   tls:
     acme-registered-email: francesco@nuvolaris.io
     acme-server-url: https://acme-v02.api.letsencrypt.org/directory
-  minio:
-    volume-size: 2
-    nuvolaris:
-      root-user: minioadmin
-      root-password: minioadmin
   configs:
     limits:
       actions:
@@ -97,5 +82,27 @@ spec:
   redis:
     volume-size: 10
     default:
-      password: s0meP@ass3               
+      password: s0meP@ass3
+    nuvolaris:
+      prefix: nuv      
+      password: s0meP@ass3
+  mongodb:
+    host: mongodb
+    volume-size: 10
+    admin: 
+      user: whisk_admin
+      password: 0therPa55
+    nuvolaris:
+      user: nuvolaris
+      password: s0meP@ass3
+    exposedExternally: False
+    useOperator: False
+  minio:
+    volume-size: 2
+    admin:
+      user: minioadmin
+      password: minioadmin    
+    nuvolaris:
+      user: nuvolaris
+      password: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG              
 

--- a/tests/openshift/whisk.yaml
+++ b/tests/openshift/whisk.yaml
@@ -61,17 +61,6 @@ spec:
     invoker:
       user: controller_admin
       password: s0meP@ass2
-  mongodb:
-    host: mongodb
-    volume-size: 10
-    admin: 
-      user: whisk_admin
-      password: 0therPa55
-    nuvolaris:
-      user: nuvolaris
-      password: s0meP@ass3
-    exposedExternally: False
-    useOperator: False
   kafka:
     host: kafka
     volume-size: 10
@@ -80,11 +69,6 @@ spec:
   tls:
     acme-registered-email: francesco@nuvolaris.io
     acme-server-url: https://acme-staging-v02.api.letsencrypt.org/directory
-  minio:
-    volume-size: 2
-    nuvolaris:
-      root-user: minioadmin
-      root-password: minioadmin
   configs:
     limits:
       actions:
@@ -99,3 +83,25 @@ spec:
     volume-size: 10
     default:
       password: s0meP@ass3
+    nuvolaris:
+      prefix: nuv      
+      password: s0meP@ass3
+  mongodb:
+    host: mongodb
+    volume-size: 10
+    admin: 
+      user: whisk_admin
+      password: 0therPa55
+    nuvolaris:
+      user: nuvolaris
+      password: s0meP@ass3
+    exposedExternally: False
+    useOperator: False
+  minio:
+    volume-size: 2
+    admin:
+      user: minioadmin
+      password: minioadmin    
+    nuvolaris:
+      user: nuvolaris
+      password: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG 

--- a/tests/whisk.yaml
+++ b/tests/whisk.yaml
@@ -57,16 +57,6 @@ spec:
     invoker:
       user: controller_admin
       password: s0meP@ass2
-  mongodb:
-    host: mongodb
-    volume-size: 10
-    admin: 
-      user: whisk_admin
-      password: 0therPa55
-    nuvolaris:
-      user: nuvolaris
-      password: s0meP@ass3
-    exposed: true
   kafka:
     host: kafka
     volume-size: 10
@@ -76,11 +66,6 @@ spec:
     port: "3233"
   scheduler:
     schedule: "* * * * *"
-  minio:
-    volume-size: 2
-    nuvolaris:
-      root-user: minioadmin
-      root-password: minioadmin
   configs:
     limits:
       actions:
@@ -94,5 +79,27 @@ spec:
   redis:
     volume-size: 10
     default:
-      password: s0meP@ass3            
+      password: s0meP@ass3
+    nuvolaris:
+      prefix: nuv      
+      password: s0meP@ass3
+  mongodb:
+    host: mongodb
+    volume-size: 10
+    admin: 
+      user: whisk_admin
+      password: 0therPa55
+    nuvolaris:
+      user: nuvolaris
+      password: s0meP@ass3
+    exposedExternally: False
+    useOperator: False
+  minio:
+    volume-size: 2
+    admin:
+      user: minioadmin
+      password: minioadmin    
+    nuvolaris:
+      user: nuvolaris
+      password: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG             
 


### PR DESCRIPTION
This PR enables cm/config specific annotations for system user nuvolaris when corresponding components are enabled

```
    minio_access_key: 
    minio_port: 
    minio_secret_key: 
    minio_url: 
    mongodb_url: 
    nuvolaris_minio_data_bucket: 
    nuvolaris_minio_static_bucket: 
    redis_prefix:
    redis_url: 
```

The corresponding whisk.yaml CRD has been updated according to this structure 

```
  redis:
    volume-size: 10
    default:
      password: xxxx
    nuvolaris:
      prefix: nuv      
      password: xxxxxx
  mongodb:
    host: mongodb
    volume-size: 10
    admin: 
      user: whisk_admin
      password: xxxxxxx
    nuvolaris:
      user: nuvolaris
      password: xxxx
    exposedExternally: False
    useOperator: False
  minio:
    volume-size: 2
    admin:
      user: xxxxx
      password: xxxxx    
    nuvolaris:
      user: nuvolaris
      password: xxxxxx
```

