### PR TITLE
Fixes for nuvolaris/nuvolaris#201, nuvolaris/nuvolaris#202

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -139,7 +139,7 @@ tasks:
     - task: instance
     - task: config
     - task: hello
-    - task: ping
+    - task: redis
     - task: mongo
     - task: minio
 
@@ -149,8 +149,8 @@ tasks:
   hello: 
     - task: t:hello
 
-  ping: 
-    - task: t:ping
+  redis: 
+    - task: t:redis
 
   workflow: 
     - kubectl -n nuvolaris apply -f tests/workflow-test.yaml
@@ -252,7 +252,7 @@ tasks:
   actions:
     - task: t:config
     - task: t:hello
-    - task: t:ping
+    - task: t:redis
     - task: t:echo
     - task: t:api
 

--- a/TaskfileTest.yml
+++ b/TaskfileTest.yml
@@ -38,7 +38,8 @@ vars:
   MINIO_USER: "minioadmin"
   MINIO_PWD : "minioadmin"
   APIKUBE:
-      sh: kubectl config view -o json | jq -r '.clusters[0].cluster.server' 
+      sh: kubectl config view -o json | jq -r '.clusters[0].cluster.server'
+
   T: ""
 
 env:
@@ -134,10 +135,19 @@ tasks:
       URL=$(wsk -i action get hello --url | tail +2)
       curl -skL $URL | grep hello
 
-  ping:
-    - wsk -i package update redis -p redis "{{.REDIS_URI}}"
-    - wsk -i action update redis/ping tests/ping.js
-    - wsk -i action invoke redis/ping -r | grep "PONG"
+  redis:
+    cmds:
+      - wsk -i package update redis -p redis "{{.REDIS_URI}}"
+      - wsk -i action update redis/ping tests/ping.js   
+      - wsk -i action invoke redis/ping -r | grep "PONG"
+      - wsk -i action invoke redis/ping -p redis "{{.REDIS_NUV_URL}}" -r | grep "PONG"
+      - wsk -i action update redis/redis tests/redis.js -p redis_url "{{.REDIS_NUV_URL}}" -p redis_prefix "{{.REDIS_NUV_PREFIX}}"
+      - wsk -i action invoke redis/redis -r | grep "world"
+    vars:
+        REDIS_NUV_PREFIX:
+          sh:  kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.redis_prefix}'
+        REDIS_NUV_URL:
+          sh:  kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.redis_url}'
 
   echo:
     - wsk -i action update echo tests/echo.js -a provide-api-key true

--- a/nuvolaris/kustomize.py
+++ b/nuvolaris/kustomize.py
@@ -286,4 +286,29 @@ def renderTemplate(where,template,data,out_template):
     out = f"deploy/{where}/{out_template}"
     ntp.spool_template(template, out, data)
     return out
+
+# generate a kustomization for a persistence volume claim using inline patchesJson6902 format
+def patchPersistentVolumeClaim(name, path, value):
+    """
+    >>> print(patchPersistentVolumeClaim("mongodb-data", "/spec/resources/requests/storage", "10Gi"), end='')
+    - target:
+        version: v1
+        kind: PersistentVolumeClaim
+        namespace: nuvolaris
+        name: mongodb-data
+      patch: |-
+        - op: replace
+          path: /spec/resources/requests/storage
+          value: 10Gi
+    """
+    return f"""- target:
+    version: v1
+    kind: PersistentVolumeClaim
+    namespace: nuvolaris
+    name: {name}
+  patch: |-
+    - op: replace
+      path: {path}
+      value: {value}
+"""  
    

--- a/nuvolaris/mongodb_standalone.py
+++ b/nuvolaris/mongodb_standalone.py
@@ -34,7 +34,8 @@ def create(owner=None):
     exposed = cfg.get('mongodb.exposedExternally') or False 
 
     data = util.get_mongodb_config_data()
-    mkust = kus.patchTemplates("mongodb-standalone", ["mongodb-auth.yaml","mongodb-cm.yaml","mongodb-sts.yaml"], data)    
+    mkust = kus.patchTemplates("mongodb-standalone", ["mongodb-auth.yaml","mongodb-cm.yaml","mongodb-sts.yaml"], data)
+    mkust += kus.patchPersistentVolumeClaim("mongodb-data","/spec/resources/requests/storage",f"{data['size']}Gi")
     mspec = kus.kustom_list("mongodb-standalone", mkust, templates=[], data=data)
 
     if owner:

--- a/nuvolaris/templates/mongodb-config.yaml
+++ b/nuvolaris/templates/mongodb-config.yaml
@@ -62,4 +62,13 @@ spec:
               readinessProbe:
                 failureThreshold: 40
                 initialDelaySeconds: 5
-                timeout: 30    
+                timeout: 30
+      volumeClaimTemplates:
+      - apiVersion: v1
+        kind: PersistentVolumeClaim
+        metadata:
+          name: data-volume
+        spec:
+          resources:
+            requests:
+              storage: {{size}}G

--- a/nuvolaris/templates/pvc-create.yaml
+++ b/nuvolaris/templates/pvc-create.yaml
@@ -14,15 +14,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
----
+
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: mongodb-data
+  name: {{pvcName}}
   namespace: nuvolaris
+  finalizers:
+  - kubernetes.io/pvc-protection
 spec:
+  storageClassName: {{storageClass}}
   accessModes:
-    - ReadWriteOnce 
+  - {{pvcAccessMode}}
   resources:
     requests:
-      storage: 10Gi
+      storage: {{size}}Gi

--- a/nuvolaris/templates/redis_manage_user_tpl.txt
+++ b/nuvolaris/templates/redis_manage_user_tpl.txt
@@ -2,10 +2,7 @@ AUTH {{redis_password}}
 {% if mode == 'create'%}
 ACL SETUSER {{namespace}}
 ACL SETUSER {{namespace}} ON >{{password}}
-ACL SETUSER {{namespace}} +SET
-ACL SETUSER {{namespace}} +GET
-ACL SETUSER {{namespace}} +DEL
-ACL SETUSER {{namespace}} ~{{prefix}}:*
+ACL SETUSER {{namespace}} +@all ~{{prefix}}*
 {% endif %}
 
 {% if mode == 'delete'%}

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -182,6 +182,12 @@ def check(f, what, res):
 
 # return redis configuration parameters with default values if not configured
 def get_redis_config_data():
+    # ensure prefix key contains : at the end to be compliant with REDIS script ACL creator
+    prefix = cfg.get("redis.nuvolaris.prefix") or "nuvolaris:"
+
+    if(not prefix.endswith(":")):
+        prefix = f"{prefix}:"
+
     data = {
         "name": "redis",
         "dir": "/redis-master-data",
@@ -190,7 +196,7 @@ def get_redis_config_data():
         "redis_password":cfg.get("redis.default.password") or "s0meP@ass3",
         "namespace":"nuvolaris",
         "password":cfg.get("redis.nuvolaris.password") or "s0meP@ass3",
-        "prefix":cfg.get("redis.nuvolaris.prefix") or "nuv"
+        "prefix": prefix
     }
     return data
 

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -112,8 +112,12 @@ def get_mongodb_config_data():
         'mongo_admin_user': cfg.get('mongodb.admin.user') or "whisk_user",
         'mongo_admin_password': cfg.get('mongodb.admin.password') or "0therPa55",
         'mongo_nuvolaris_user': cfg.get('mongodb.nuvolaris.user') or "nuvolaris",
-        'mongo_nuvolaris_password': cfg.get('mongodb.nuvolaris.password') or "s0meP@ass3"
-    }
+        'mongo_nuvolaris_password': cfg.get('mongodb.nuvolaris.password') or "s0meP@ass3",
+        'size': cfg.get('mongodb.volume-size') or 10,
+        'pvcName': 'mongodb-data',
+        'storageClass':cfg.get("nuvolaris.storageClass"),
+        'pvcAccessMode':'ReadWriteOnce'    
+        }
     return data
 
 # return configuration parameters for the standalone controller

--- a/tests/kind/mongodb_op_test.ipy
+++ b/tests/kind/mongodb_op_test.ipy
@@ -26,6 +26,7 @@ import logging
 
 # test
 assert(cfg.configure(tu.load_sample_config()))
+cfg.detect_storage()
 assert(cfg.put("mongodb.useOperator", True))
 assert(mdb.create())
 while not kube.wait("pod/nuvolaris-mongodb-0", "condition=ready"): pass
@@ -34,6 +35,7 @@ assert(kube.get("mdbc/nuvolaris-mongodb"))
 
 !kubectl get secret -n nuvolaris -ojson nuvolaris-mongodb-nuvolaris-nuvolaris | jq -r '.data | with_entries(.value |= @base64d)'
 
+assert(kube.kubectl("get", f"cm/config", jsonpath="{.metadata.annotations.mongodb_url}"))
 assert(mdb.delete())
 
 #!kubectl -n nuvolaris delete all --all

--- a/tests/kind/mongodb_std_test.ipy
+++ b/tests/kind/mongodb_std_test.ipy
@@ -26,6 +26,7 @@ import logging
 
 # test
 assert(cfg.configure(tu.load_sample_config()))
+cfg.detect_storage()
 assert(cfg.put("mongodb.useOperator", False))
 assert(mdb.create())
 while not kube.wait("pod/nuvolaris-mongodb-0", "condition=ready"): pass
@@ -33,6 +34,8 @@ assert(kube.get("service/nuvolaris-mongodb-svc"))
 
 flavour = kube.kubectl("get", "pod/nuvolaris-mongodb-0", jsonpath="{.metadata.labels.nuvolaris\.mongodb\.flavour}")
 assert("standalone"==flavour[0])
+
+assert(kube.kubectl("get", f"cm/config", jsonpath="{.metadata.annotations.mongodb_url}"))
 
 assert(mdb.delete())
 

--- a/tests/kind/whisk.yaml
+++ b/tests/kind/whisk.yaml
@@ -82,7 +82,7 @@ spec:
     default:
       password: s0meP@ass3
     nuvolaris:
-      prefix: nuv      
+      prefix: nuvolaris      
       password: s0meP@ass3
   mongodb:
     host: mongodb

--- a/tests/redis.js
+++ b/tests/redis.js
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+async function main(args) {
+    // connnect to the redis database
+    const db = require("redis").createClient({"url":args.redis_url})
+    await db.connect()
+    let p = args.redis_prefix
+    // execute a set and get command
+    try   {
+        await db.set(p+"hello", "world")
+        return db.get(p+"hello").then(r => ({
+        "hello": r
+        }))
+    }  
+    catch (error) {
+        return {
+            "error":"call to redis failed"
+        }
+    }
+
+}

--- a/tests/whisk.yaml
+++ b/tests/whisk.yaml
@@ -85,7 +85,7 @@ spec:
       password: s0meP@ass3
   mongodb:
     host: mongodb
-    volume-size: 10
+    volume-size: 5
     admin: 
       user: whisk_admin
       password: 0therPa55


### PR DESCRIPTION
This PR contributes

- fixes redis nuvolaris permissions 
- add tests inside the testing operator tasks to verify that nuvolaris user can ping redis and has access to his prefixed keys
- add REDIS_PREFIX as metadata for any new created users (was missing from the response of nuv login calls)
- honor MongoDB volume size configured values