### PR TITLE
Implements nuvolaris/nuvolaris#200

### DIFF
--- a/actions/Taskfile.yml
+++ b/actions/Taskfile.yml
@@ -74,7 +74,7 @@ tasks:
 
   login:webtest:
     - >
-      curl -X POST {{.APIHOST}}/api/v1/web/whisk-system/nuv/login -H "Content-Type: application/json" -d '{"login": "franztt", "password": "apassw0rd"}'
+      curl -X POST {{.APIHOST}}/api/v1/web/whisk-system/nuv/login -H "Content-Type: application/json" -d '{"login": "{{.USERNAME}}", "password": "{{.PASSWORD}}"}'
 
   login:all:
     - task: login:prepare

--- a/deploy/minio/01-minio-dep.yaml
+++ b/deploy/minio/01-minio-dep.yaml
@@ -31,6 +31,9 @@ spec:
     metadata:
       labels:
         app: minio
+        name: minio
+      annotations:
+        whisks.nuvolaris.org/annotate-version: "true"   
     spec:
       volumes:
       - name: storage

--- a/deploy/mongodb-standalone/mongodb-sts.yaml
+++ b/deploy/mongodb-standalone/mongodb-sts.yaml
@@ -32,6 +32,7 @@ spec:
     metadata:
       labels:
         app: nuvolaris-mongodb
+        name: nuvolaris-mongodb
     spec:
       containers:
       - image: mongo:5.0.11

--- a/deploy/nuvolaris-operator/operator-pod.yaml
+++ b/deploy/nuvolaris-operator/operator-pod.yaml
@@ -20,6 +20,10 @@ kind: Pod
 metadata:
   name: nuvolaris-operator
   namespace: nuvolaris
+  annotations:
+    whisks.nuvolaris.org/annotate-version: "true"
+  labels:
+    name: nuvolaris-operator     
 spec:
   serviceAccount: nuvolaris-operator
   containers:

--- a/deploy/redis/redis-set.yaml
+++ b/deploy/redis/redis-set.yaml
@@ -30,6 +30,9 @@ spec:
     metadata:
       labels:
         name: redis
+        app: redis
+      annotations:
+        whisks.nuvolaris.org/annotate-version: "true"         
     spec:
       restartPolicy: Always  
       containers:

--- a/nuvolaris/main.py
+++ b/nuvolaris/main.py
@@ -32,6 +32,7 @@ import nuvolaris.minio as minio
 import nuvolaris.openwhisk_patcher as patcher
 import nuvolaris.minio_static as static
 import nuvolaris.whisk_actions_deployer as system
+import nuvolaris.version_util as version_util
 
 # tested by an integration test
 @kopf.on.login()
@@ -185,6 +186,8 @@ def whisk_post_create(name, state):
         state['whisk-system']="on"
     else:                   
         state['whisk-system']="on"
+    
+    version_util.annotate_operator_components_version()    
 
 # tested by an integration test
 @kopf.on.delete('nuvolaris.org', 'v1', 'whisks')

--- a/nuvolaris/templates/couchdb-init.yaml
+++ b/nuvolaris/templates/couchdb-init.yaml
@@ -28,6 +28,9 @@ spec:
       namespace: nuvolaris
       labels:
         job: couchdb-init
+        name: couchdb-init
+      annotations:
+        whisks.nuvolaris.org/annotate-version: "true"
     spec:
       serviceAccount: nuvolaris-operator
       restartPolicy: Never      

--- a/nuvolaris/templates/couchdb-set-tpl.yaml
+++ b/nuvolaris/templates/couchdb-set-tpl.yaml
@@ -31,6 +31,8 @@ spec:
     metadata:
       labels:
         name: couchdb
+      annotations:
+        whisks.nuvolaris.org/annotate-version: "true"  
     spec:
       restartPolicy: Always
       containers:

--- a/nuvolaris/templates/mongodb-config.yaml
+++ b/nuvolaris/templates/mongodb-config.yaml
@@ -56,7 +56,10 @@ spec:
         spec:
           metadata:
             labels:
+              name: mongodb
               nuvolaris.mongodb.flavour: operator
+            annotations:
+              whisks.nuvolaris.org/annotate-version: "true"   
           containers:
             - name: mongodb-agent
               readinessProbe:

--- a/nuvolaris/templates/mongodb-config.yaml
+++ b/nuvolaris/templates/mongodb-config.yaml
@@ -53,13 +53,13 @@ spec:
   statefulSet:
     spec:
       template:
-        spec:
-          metadata:
-            labels:
-              name: mongodb
-              nuvolaris.mongodb.flavour: operator
-            annotations:
-              whisks.nuvolaris.org/annotate-version: "true"   
+        metadata:
+          labels:
+            name: mongodb
+            nuvolaris.mongodb.flavour: operator
+          annotations:
+            whisks.nuvolaris.org/annotate-version: "true"       
+        spec:  
           containers:
             - name: mongodb-agent
               readinessProbe:

--- a/nuvolaris/templates/mongodb-sts.yaml
+++ b/nuvolaris/templates/mongodb-sts.yaml
@@ -31,8 +31,11 @@ spec:
   template:
     metadata:
       labels:
+        name: mongodb
         app: nuvolaris-mongodb
         nuvolaris.mongodb.flavour: standalone
+      annotations:
+        whisks.nuvolaris.org/annotate-version: "true"         
     spec:
       containers:
       - image: mongo:5.0.11

--- a/nuvolaris/templates/standalone-sts.yaml
+++ b/nuvolaris/templates/standalone-sts.yaml
@@ -36,7 +36,8 @@ spec:
       labels:
         name: controller
         app: controller
-
+      annotations:
+        whisks.nuvolaris.org/annotate-version: "true"
     spec:
       serviceAccountName: nuvolaris-openwhisk-core
       restartPolicy: Always

--- a/nuvolaris/version_util.py
+++ b/nuvolaris/version_util.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import logging
+import nuvolaris.openwhisk as openwhisk
+import nuvolaris.kube as kube
+
+def annotate_operator_components_version():
+    """
+    This functions scans for pod matching the annotations whisks.nuvolaris.org/annotate-version: "true"
+    and uses pod metadata.labels.name and spec.containers.image to annotate the global config map cm/config
+    """
+    try:
+        logging.info("**** annotating nuvolaris operator component versions")
+        pods = kube.kubectl("get","pods",jsonpath="{.items[?(@.metadata.annotations.whisks\.nuvolaris\.org\/annotate-version)]}")
+
+        for pod in pods:
+            if(pod['metadata'].get('labels') and pod['metadata']['labels'].get('name')):
+                pod_name = pod['metadata']['labels']['name']
+                pod_image = pod['spec']['containers'][0]['image']
+
+                if(pod_name):
+                    openwhisk.annotate(f"{pod_name}_version={pod_image}")
+            else:
+                logging.warn("**** found a pod with whisks.nuvolaris.org/annotate-version without metadata.labels.name attribute")
+                logging.warn(pod)
+        
+        logging.info("**** completed annotation of nuvolaris operator component versions")       
+    except Exception as e:
+        logging.error(e)


### PR DESCRIPTION
This PR contributes a utility to automatically annotate into operator cm/config config map all deployed pod image pod versions. 

Pod to be selected needs to have

```
      annotations:
        whisks.nuvolaris.org/annotate-version: "true" 
```

and must have a `metadata.labels.name` attributes set.

For every matching pod an annotations` {pod.metadata.labels.name}_version={pod.spec.container[0].image}` is added
   