### PR TITLE
Implements nuvolaris/nuvolaris#213

### DIFF
--- a/deploy/nuvolaris-permissions/whisk-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-crd.yaml
@@ -58,6 +58,9 @@ spec:
                       enum:
                       - http
                       - https
+                    kube:
+                      description: label representing the kubernetes runtime used to implement specific logic (kind, eks, aks, lks, microk8s, k3s, openshift). Defaulted to detect which is causing the operator to autodetect the k8s runtime.
+                      type: string                     
                 components:
                   description: it allows which components needs to be deployed by default. For a minimal setup openwhisk and couchdb are required to be set to true
                   type: object

--- a/nuvolaris/kopf_util.py
+++ b/nuvolaris/kopf_util.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import json, logging
+
+def normalize(item:tuple):
+    """
+    Takes a kopf diff tuple and normalize it by concatenating the modified element into a path attribute
+    >>> item = ('change', ('spec','component','tls'), 'true', 'false')
+    >>> print(normalize(item))
+    {'path': 'spec.component.tls', 'action': 'change', 'old': 'true', 'new': 'false'}
+    """
+    res = {}    
+    path = ""
+    for path_element in item[1]:
+        path = f"{path}{path_element}."
+    
+    res['path']=path[:-1]
+    res['action']=item[0]
+    res['old']=item[2]
+    res['new']=item[3]
+
+    return res
+
+def endpoint(response: dict, item: dict):
+    """
+    Forces an update of the apihost endpoint if any of these two attributes has been changed/added
+    """
+    if(item['path']=='spec.components.tls' or item['path']=='spec.nuvolaris.apihost'):
+        response["endpoint"]="update"
+
+def openwhisk(response: dict, item: dict):
+    """
+    Forces an update of Openwhisk if a change in the global spec.config has been detected.
+    This will force the redeploy of the Openwhisk controller/invoker where supported
+    """
+    if item['path'].find('spec.configs') >= 0:
+        response["openwhisk"]="update" 
+
+def check_component(response: dict, item: dict, cmp_spec, cmp_key):
+    """
+    Check if the componet identified by cmp_spec has been enabled or disabled
+    """
+    if item['path'].find(cmp_spec) > -1:
+        if(item['new']):
+            response[cmp_key]="create"
+        else: 
+            response[cmp_key]="delete"       
+
+def evaluate_differences(response: dict, differences: list):
+    """
+    Iterate over the difference list to find which components the
+    nuvolaris operator need to deploy/undeploy
+    """
+    for d in differences:
+        check_component(response, d,"spec.components.couchdb","couchdb")
+        check_component(response, d,"spec.components.mongodb","mongodb")
+        check_component(response, d,"spec.components.kafka","kafka")
+        check_component(response, d,"spec.components.zookeeper","zookeeper")
+        check_component(response, d,"spec.components.redis","redis")
+        check_component(response, d,"spec.components.cron","cron")
+        check_component(response, d,"spec.components.minio","minio")
+        check_component(response, d,"spec.components.static","static") 
+        check_component(response, d,"spec.components.postgres","postgres")
+        openwhisk(response, d)           
+        endpoint(response, d)
+        
+def detect_component_changes(kopf_diff):
+    """
+    Analyze a kopf diff object and attempt to establish which component must be added/removed/updated by the operator.
+    Typically a kopf diff object has a structure like ((action, n-tuple of object or field path, old, new),)
+    Will return a list of items reporting the specific action to be done on any nuvolaris operator managed component
+    >>> data = (('change',('spec','components','mongodb'), True, False),('change',('spec','components','tls'), True, False),('change', ('spec','configs','limits','actions','sequence-maxLength'), 10, 20))
+    >>> what_to_do = detect_component_changes(data)
+    >>> print(what_to_do['endpoint'])
+    update
+    >>> print(what_to_do['openwhisk'])    
+    update
+    >>> print(what_to_do['mongodb'])        
+    delete
+    """
+    differences = list()
+    for t in kopf_diff:
+        logging.info(f"*** processing difference {t}")
+        differences.append(normalize(t))
+
+    response = {}
+    evaluate_differences(response, differences)
+
+    return response

--- a/nuvolaris/kube.py
+++ b/nuvolaris/kube.py
@@ -120,16 +120,15 @@ def apply(obj, namespace="nuvolaris"):
         obj = json.dumps(obj)
     return kubectl("apply", "-f", "-", namespace=namespace, input=obj)
 
-# apply an object
+# apply an expanded template
 def applyTemplate(name, data, namespace="nuvolaris"):
     obj = tpl.expand_template(name, data)
     return kubectl("apply", "-f", "-", namespace=namespace, input=obj)
 
-# delete an object
+# delete an expanded template
 def deleteTemplate(name, data, namespace="nuvolaris"):
     obj = tpl.expand_template(name, data)
     return kubectl("delete", "-f", "-", namespace=namespace, input=obj)
-
 
 def get(name, namespace="nuvolaris"):
     try:

--- a/nuvolaris/kustomize.py
+++ b/nuvolaris/kustomize.py
@@ -70,6 +70,16 @@ def kustomize(where, *what, templates=[], data={}):
     return res.stdout.decode("utf-8")
 
 # execute the kustomization of a folder under "deploy"
+# specified with `where` returning the expanded kustomization
+# it expects that the folder contains already a full kustomization
+# this methid will be used to extract the existing kustomization in case
+# the nuvolaris operator needs to delete a component
+def build(where):
+    dir = f"deploy/{where}"
+    res = subprocess.run(["kustomize", "build", dir], capture_output=True)
+    return res.stdout.decode("utf-8")   
+
+# execute the kustomization of a folder under "deploy"
 # specified with `where`
 # it generate a kustomization.yaml, adding the header 
 # then including all the files of that folder as resources limited to the one

--- a/nuvolaris/main.py
+++ b/nuvolaris/main.py
@@ -29,7 +29,7 @@ import nuvolaris.mongodb as mongodb
 import nuvolaris.issuer as issuer
 import nuvolaris.endpoint as endpoint
 import nuvolaris.minio as minio
-import nuvolaris.openwhisk_patcher as patcher
+import nuvolaris.patcher as patcher
 import nuvolaris.minio_static as static
 import nuvolaris.whisk_actions_deployer as system
 import nuvolaris.version_util as version_util
@@ -195,7 +195,7 @@ def whisk_post_create(name, state):
     else:                   
         state['whisk-system']="on"
     
-    version_util.annotate_operator_components_version()    
+    version_util.annotate_operator_components_version()  
 
 # tested by an integration test
 @kopf.on.delete('nuvolaris.org', 'v1', 'whisks')
@@ -240,9 +240,7 @@ def whisk_delete(spec, **kwargs):
     if cfg.get('components.postgres'):
         msg = postgres.delete()
         logging.info(msg)
-             
-    
-                         
+                 
 # tested by integration test
 #@kopf.on.field("service", field='status.loadBalancer')
 def service_update(old, new, name, **kwargs):
@@ -288,10 +286,9 @@ def whisk_update(spec, status, namespace, diff, name, **kwargs):
 
     logging.debug("*** dumping new configuration parameters")
     cfg.dump_config()
+    
     owner = kube.get(f"wsk/{name}")
-
-    if cfg.get('components.openwhisk'):
-        patcher.redeploy_whisk(owner)
+    patcher.patch(diff, status, owner)
 
 @kopf.on.resume('nuvolaris.org', 'v1', 'whisks')
 def whisk_resume(spec, name, **kwargs):

--- a/nuvolaris/mongodb.py
+++ b/nuvolaris/mongodb.py
@@ -100,13 +100,13 @@ def update_system_cm_for_mdb():
     except Exception as e:
         logging.error(f"failed to build mongodb_url for nuvolaris database: {e}")    
 
-def delete():
+def delete(owner=None):
     useOperator = cfg.get('mongodb.useOperator') or False
 
     if useOperator:
-        return operator.delete()
+        return operator.delete(owner)
 
-    return standalone.delete()    
+    return standalone.delete(owner)    
 
 def init():
     return "TODO"
@@ -171,4 +171,23 @@ def delete_db_user(namespace, database):
         return None
     except Exception as e:
         logging.error(f"failed to remove Mongodb database {namespace} authorization id and key: {e}")
-        return None         
+        return None
+
+def patch(status, action, owner=None):
+    """
+    Called the the operator patcher to create/delete mongodb
+    """
+    try:
+        logging.info(f"*** handling request to {action} mongodb")  
+        if  action == 'create':
+            msg = create(owner)
+            status['whisk_create']['mongodb']='on'
+        else:
+            msg = delete(owner)
+            status['whisk_create']['mongodb']='off'
+
+        logging.info(msg)        
+        logging.info(f"*** hanlded request to {action} mongodb") 
+    except Exception as e:
+        logging.error('*** failed to update mongodb: %s' % e)
+        status['whisk_create']['mongodb']='error'                 

--- a/nuvolaris/mongodb_operator.py
+++ b/nuvolaris/mongodb_operator.py
@@ -106,7 +106,16 @@ def create(owner=None):
         logging.info("*** something went wrong deploying mongodb operator")    
     return res 
 
-def delete():
+
+def delete_by_owner():
+    spec = kus.build("mongodb-operator-deploy")
+    res = kube.delete(spec)
+    spec = kus.build("mongodb-operator")
+    res = kube.delete(spec)
+    logging.info(f"delete mongodb: {res}")
+    return res
+
+def delete_by_spec():
     spec = cfg.get("state.mongodb.spec")
     res = False
     if spec:
@@ -119,5 +128,8 @@ def delete():
         logging.info(f"delete mongodb-operator: {res}")        
     return res
 
-def init():
-    return "TODO"
+def delete(owner=None):
+    if owner:       
+        return delete_by_owner()
+    else:
+        return delete_by_spec()

--- a/nuvolaris/mongodb_standalone.py
+++ b/nuvolaris/mongodb_standalone.py
@@ -49,16 +49,25 @@ def create(owner=None):
     util.wait_for_pod_ready("{.items[?(@.metadata.labels.app == 'nuvolaris-mongodb')].metadata.name}")
  
     logging.info("*** created mongodb-standalone")    
-    return res 
+    return res
 
-def delete():
+def delete_by_owner():
+    spec = kus.build("mongodb-standalone")
+    res = kube.delete(spec)
+    logging.info(f"delete mongodb: {res}")
+    return res
+
+def delete_by_spec():
     spec = cfg.get("state.mongodb.spec")
     res = False
     if spec:
         res = kube.delete(spec)
         logging.info(f"delete mongodb: {res}")
-
+    
     return res
 
-def init():
-    return "TODO"
+def delete(owner=None):
+    if owner:        
+        return delete_by_owner()
+    else:
+        return delete_by_spec()

--- a/tests/kind/minio_test.ipy
+++ b/tests/kind/minio_test.ipy
@@ -43,6 +43,6 @@ actual_minio_root_user = kube.kubectl("get", f"pods/{pod_name}", jsonpath="{.spe
 configured_minio_root_user = cfg.get('minio.admin.user')
 assert(actual_minio_root_user[0] == configured_minio_root_user)
 
-cm_minio_url = kube.kubectl("get", f"cm/config", jsonpath="{.metadata.annotations.minio_url}")
+cm_minio_url = kube.kubectl("get", f"cm/config", jsonpath="{.metadata.annotations.minio_host}")
 assert(cm_minio_url)
 assert(minio.delete())


### PR DESCRIPTION
This PR adds these redeployments capabilities to the community operator

```
- change in spec.components.tls or spec.nuvolaris.apihost -> redeployment of OpenWhisk api endpoint (apihost)
- change in spec.configs -> redeployment of OpenWhisk controller
- change in spec.components.mongodb -> add/remove mongodb
- change in spec.components.redis -> add/remove redis
- change in spec.components.cron -> add/remove cron
- change in spec.components.minio -> add/remove minio
- change in spec.components.static -> add/remove minio static provider
- change in spec.components.postgres -> add/remove postgres
```
