### PR TITLE
Implements nuvolaris/nuvolaris#221

### DIFF
--- a/nuvolaris/templates/generic-ingress-tpl.yaml
+++ b/nuvolaris/templates/generic-ingress-tpl.yaml
@@ -26,14 +26,20 @@ metadata:
       {% if tls %}
       cert-manager.io/cluster-issuer: "letsencrypt-issuer"
       {% endif %}
-      {% if is_static_ingress and apply_nginx_rewrite_rule %}
+      {% if ingress_class == 'traefik' %}
+      traefik.ingress.kubernetes.io/transport.respondingTimeouts.readTimeout: "{{route_timeout_seconds}}"
+      traefik.ingress.kubernetes.io/transport.respondingTimeouts.writeTimeout: "{{route_timeout_seconds}}"
+      traefik.ingress.kubernetes.io/transport.respondingTimeouts.idleTimeout: "{{route_timeout_seconds}}"
+      {% else %}
       nginx.ingress.kubernetes.io/proxy-body-size: "48m"
-      nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "{{route_timeout_seconds}}"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "{{route_timeout_seconds}}"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "{{route_timeout_seconds}}"      
+      {% endif %}       
+      {% if is_static_ingress and apply_nginx_rewrite_rule %}
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: {{rewrite_target}}/$1
-      {% endif %}
+      {% endif %}     
       {% if is_static_ingress and apply_traefik_prefix_middleware %}
       traefik.ingress.kubernetes.io/router.middlewares: nuvolaris-{{middleware_ingress_name}}@kubernetescrd
       {% endif %}      

--- a/nuvolaris/templates/generic-openshift-route-tpl.yaml
+++ b/nuvolaris/templates/generic-openshift-route-tpl.yaml
@@ -22,8 +22,9 @@ metadata:
   namespace: nuvolaris
   labels:
     app: {{route_name}}
-  {% if is_static_ingress and apply_route_rewrite_rule %}
   annotations:
+    haproxy.router.openshift.io/timeout={{route_timeout_seconds}}s   
+  {% if is_static_ingress and apply_route_rewrite_rule %}
     haproxy.router.openshift.io/rewrite-target: {{rewrite_target}}/      
   {% endif %}  
 spec:

--- a/nuvolaris/time_util.py
+++ b/nuvolaris/time_util.py
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import logging, re
+
+def duration_in_second(string):
+    """
+    Conveniently parse a string represting a finite time unit in multiple format (s, m, h, d, sec, min, hour, day) and convert it into seconds.    
+    >>> import nuvolaris.time_util as tu
+    >>> tu.duration_in_second("1s")        
+    1
+    >>> tu.duration_in_second("1m")        
+    60
+    >>> tu.duration_in_second("1h")        
+    3600
+    >>> tu.duration_in_second("1d")    
+    86400
+    >>> tu.duration_in_second("1 s")
+    1
+    >>> tu.duration_in_second("1 d")
+    86400
+    >>> tu.duration_in_second("1 sec")
+    1
+    >>> tu.duration_in_second("1 min")
+    60
+    >>> tu.duration_in_second("1 hour")
+    3600
+    >>> tu.duration_in_second("1 day")
+    86400
+    >>> tu.duration_in_second("5  min")
+    300
+    >>> tu.duration_in_second("5min")
+    300
+    >>> tu.duration_in_second("10  min")
+    600
+    """
+    mult = {"s": 1, "m": 60, "h": 60*60, "d": 60*60*24,"sec": 1, "min": 60, "hour": 60*60, "day": 60*60*24}
+    parts = re.findall(r"(\d+(?:\s+)?)([\w])", string)
+    total_seconds = sum(int(x) * mult[m] for x, m in parts)
+    return total_seconds

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -243,4 +243,7 @@ def wait_for_service(jsonpath,namespace="nuvolaris"):
     if(service_names):
         return service_names[0]
 
-    raise Exception(f"could not find any pod matching jsonpath={jsonpath}")                               
+    raise Exception(f"could not find any pod matching jsonpath={jsonpath}")
+
+def get_controller_http_timeout():    
+    return cfg.get("configs.limits.time.limit-max") or "5min"                          


### PR DESCRIPTION
This PR provides support to align controller router/ingress timeout to the max timeout assigned to OpenWhisk controller for running actions converting the configured values in seconds.

Openwhisk timeout can be configured using ones of these formats:

- seconds: N s, Ns, N sec, Nsec
- minutes: N m, Nm, N min, Nmin
- hour: N h, Nh, N hour, Nhour
- day: N d, Nd, N day, Nday

The value will be passed as is to OpenWhisk configuration and converted in seconds to be used four route/ingress as most of the provider supports only seconds.