### PR TITLE
Implements nuvolaris/nuvolaris#231

### DIFF
--- a/deploy/nuvolaris-permissions/whisk-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-crd.yaml
@@ -457,7 +457,34 @@ spec:
                               type: integer
                           required:
                           - blackbox-fraction
-                          - timeout-factor                                
+                          - timeout-factor
+                    couchdb:
+                      description: configure couchdb limits
+                      type: object
+                      properties:
+                        resources:
+                          description: resource limits specification for the controller container
+                          type: object
+                          properties:
+                            cpu-req:
+                              description: container cpu requested resources. Defaulted to 2
+                              type: string
+                            cpu-lim:
+                              description: max container cpu allowed resources. Defaulted to 4
+                              type: string
+                            mem-req:
+                              description: container memory requested. Defaulted to 1G
+                              type: string
+                            mem-lim:
+                              description: container container max memory allowed. Defaulted to 2G
+                              type: string
+                          required:
+                          - cpu-req
+                          - cpu-lim 
+                          - mem-req 
+                          - mem-lim
+                      required:
+                      - resources                                           
                     controller:
                       description: configure the OW controller
                       type: object
@@ -474,6 +501,27 @@ spec:
                           - WARN
                           - ERROR
                           - TRACE
+                        resources:
+                          description: resource limits specification for the controller container
+                          type: object
+                          properties:
+                            cpu-req:
+                              description: container cpu requested resources. Defaulted to 2
+                              type: string
+                            cpu-lim:
+                              description: max container cpu allowed resources. Defaulted to 4
+                              type: string
+                            mem-req:
+                              description: container memory requested. Defaulted to 1G
+                              type: string
+                            mem-lim:
+                              description: container container max memory allowed. Defaulted to 2G
+                              type: string
+                          required:
+                          - cpu-req
+                          - cpu-lim 
+                          - mem-req 
+                          - mem-lim  
                       required:
                       - javaOpts                           
                     invoker:
@@ -501,6 +549,27 @@ spec:
                               type: string
                           required:
                           - userMemory
+                        resources:
+                          description: resource limits specification for the controller container
+                          type: object
+                          properties:
+                            cpu-req:
+                              description: container cpu requested resources. Defaulted to 2
+                              type: string
+                            cpu-lim:
+                              description: max container cpu allowed resources. Defaulted to 4
+                              type: string
+                            mem-req:
+                              description: container memory requested. Defaulted to 1G
+                              type: string
+                            mem-lim:
+                              description: container container max memory allowed. Defaulted to 2G
+                              type: string
+                          required:
+                          - cpu-req
+                          - cpu-lim 
+                          - mem-req 
+                          - mem-lim                           
                       required:
                       - javaOpts
                       - containerPool                                                                                                                                                                                

--- a/nuvolaris/couchdb.py
+++ b/nuvolaris/couchdb.py
@@ -58,7 +58,11 @@ def create(owner=None):
         "name": "couchdb", 
         "size": cfg.get("couchdb.volume-size", "COUCHDB_VOLUME_SIZE", 10), 
         "dir": "/opt/couchdb/data",
-        "storageClass": cfg.get("nuvolaris.storageClass")
+        "storageClass": cfg.get("nuvolaris.storageClass"),
+        "container_cpu_req": cfg.get('configs.couchdb.resources.cpu-req') or "1",
+        "container_cpu_lim": cfg.get('configs.couchdb.resources.cpu-lim') or "2",
+        "container_mem_req": cfg.get('configs.couchdb.resources.mem-req') or "1G",
+        "container_mem_lim": cfg.get('configs.couchdb.resources.mem-lim') or "2G"
     }
 
     kus.processTemplate("couchdb","couchdb-set-tpl.yaml",data,"couchdb-set_generated.yaml")

--- a/nuvolaris/templates/couchdb-set-tpl.yaml
+++ b/nuvolaris/templates/couchdb-set-tpl.yaml
@@ -44,14 +44,16 @@ spec:
             drop:
             - ALL
         imagePullPolicy: "Always"
-        resources:
-          requests:
-            memory: "1G"
-          limits:
-            memory: "4G"
         {% else %}
         imagePullPolicy: "IfNotPresent"
         {% endif %}
+        resources:
+          requests:
+            memory: "{{container_mem_req}}"
+            cpu : "{{container_cpu_req}}"
+          limits:
+            memory: "{{container_mem_lim}}"
+            cpu : "{{container_cpu_lim}}"
         ports:
         - name: couchdb
           containerPort: 5984

--- a/nuvolaris/templates/standalone-sts.yaml
+++ b/nuvolaris/templates/standalone-sts.yaml
@@ -45,7 +45,7 @@ spec:
       - name: controller
         imagePullPolicy: "IfNotPresent"
         image: "ghcr.io/nuvolaris/openwhisk-controller:0.3.0-morpheus.22122609"       
-        command: ["/bin/bash", "-c", "/init.sh `hostname | awk -F '-' '{print $NF}'`"]     
+        command: ["/bin/bash", "-c", "/init.sh `hostname | awk -F '-' '{print $NF}'`"]             
         ports:
         - name: controller
           containerPort: 8080
@@ -73,6 +73,13 @@ spec:
           capabilities:
             drop:
             - ALL
+        resources:
+          requests:
+            memory: "{{container_mem_req}}"
+            cpu : "{{container_cpu_req}}"
+          limits:
+            memory: "{{container_mem_lim}}"
+            cpu : "{{container_cpu_lim}}"            
         env:
 
         - name: "PORT"

--- a/nuvolaris/user_handlers.py
+++ b/nuvolaris/user_handlers.py
@@ -56,7 +56,7 @@ def whisk_user_create(spec, name, **kwargs):
         minio.create_ow_storage(state, ucfg, user_metadata, owner)
 
     if(cfg.get('components.minio') and ucfg.get('object-storage.route.enabled') and cfg.get('components.static')):
-        res = static.create_ow_static_endpoint(ucfg,owner)
+        res = static.create_ow_static_endpoint(ucfg,user_metadata, owner)
         logging.info(f"OpenWhisk static endpoint for {ucfg.get('namespace')} added = {res}")
         state['static']= res
 

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -145,6 +145,10 @@ def get_standalone_config_data():
         "concurrency_limit_std": cfg.get("configs.limits.concurrency.limit-std") or 1, 
         "concurrency_limit_max": cfg.get("configs.limits.concurrency.limit-max") or 1,
         "controller_java_opts": cfg.get('configs.controller.javaOpts') or "-Xmx2048M",
+        "container_cpu_req": cfg.get('configs.controller.resources.cpu-req') or "1",
+        "container_cpu_lim": cfg.get('configs.controller.resources.cpu-lim') or "2",
+        "container_mem_req": cfg.get('configs.controller.resources.mem-req') or "1G",
+        "container_mem_lim": cfg.get('configs.controller.resources.mem-lim') or "2G"
     }
     return data
 

--- a/tests/kind/whisk.yaml
+++ b/tests/kind/whisk.yaml
@@ -79,6 +79,17 @@ spec:
         fires-perMinute: 999
     controller:
       javaOpts: "-Xmx2048M"
+      resources:
+        cpu-req: 1
+        cpu-lim: 2
+        mem-req: "1G"
+        mem-lim: "2G"
+    couchdb:
+      resources:
+        cpu-req: 1
+        cpu-lim: 2
+        mem-req: "512M"
+        mem-lim: "1G"        
   redis:
     volume-size: 10
     default:


### PR DESCRIPTION
feature: added possibility to customize cpu and memory resources for couchdb and controller containers. To setup the specific values defines a whisk.yaml containing in spec.configs something like

```
  configs:
    controller:
      javaOpts: "-Xmx2048M"
      resources:
        cpu-req: 1
        cpu-lim: 2
        mem-req: "1G"
        mem-lim: "2G"
    couchdb:
      resources:
        cpu-req: 1
        cpu-lim: 2
        mem-req: "512M"
        mem-lim: "1G" 

```

default values for cpu req and lim are 1 and 2
default values for men req and lim are 1G and 2G.
