### PR TITLE
fix: using proper string format in newly added whisk.yaml attributes

### DIFF
--- a/tests/kind/whisk.yaml
+++ b/tests/kind/whisk.yaml
@@ -80,14 +80,14 @@ spec:
     controller:
       javaOpts: "-Xmx2048M"
       resources:
-        cpu-req: 1
-        cpu-lim: 2
+        cpu-req: "1"
+        cpu-lim: "2"
         mem-req: "1G"
         mem-lim: "2G"
     couchdb:
       resources:
-        cpu-req: 1
-        cpu-lim: 2
+        cpu-req: "1"
+        cpu-lim: "2"
         mem-req: "512M"
         mem-lim: "1G"        
   redis:


### PR DESCRIPTION
 using proper string format in newly added whisk.yaml attributes