### PR TITLE
Fix nuvolaris/nuvolaris#231

### DIFF
--- a/deploy/nuvolaris-permissions/whisk-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-crd.yaml
@@ -467,10 +467,10 @@ spec:
                           type: object
                           properties:
                             cpu-req:
-                              description: container cpu requested resources. Defaulted to 2
+                              description: container cpu requested resources. Defaulted to 256m
                               type: string
                             cpu-lim:
-                              description: max container cpu allowed resources. Defaulted to 4
+                              description: max container cpu allowed resources. Defaulted to 1
                               type: string
                             mem-req:
                               description: container memory requested. Defaulted to 1G
@@ -504,12 +504,12 @@ spec:
                         resources:
                           description: resource limits specification for the controller container
                           type: object
-                          properties:
+                          properties:                         
                             cpu-req:
-                              description: container cpu requested resources. Defaulted to 2
+                              description: container cpu requested resources. Defaulted to 500m
                               type: string
                             cpu-lim:
-                              description: max container cpu allowed resources. Defaulted to 4
+                              description: max container cpu allowed resources. Defaulted to 1
                               type: string
                             mem-req:
                               description: container memory requested. Defaulted to 1G
@@ -550,14 +550,14 @@ spec:
                           required:
                           - userMemory
                         resources:
-                          description: resource limits specification for the controller container
+                          description: resource limits specification for the invoker container
                           type: object
                           properties:
                             cpu-req:
-                              description: container cpu requested resources. Defaulted to 2
+                              description: container cpu requested resources. Defaulted to 500m
                               type: string
                             cpu-lim:
-                              description: max container cpu allowed resources. Defaulted to 4
+                              description: max container cpu allowed resources. Defaulted to 1
                               type: string
                             mem-req:
                               description: container memory requested. Defaulted to 1G

--- a/nuvolaris/couchdb.py
+++ b/nuvolaris/couchdb.py
@@ -59,10 +59,11 @@ def create(owner=None):
         "size": cfg.get("couchdb.volume-size", "COUCHDB_VOLUME_SIZE", 10), 
         "dir": "/opt/couchdb/data",
         "storageClass": cfg.get("nuvolaris.storageClass"),
-        "container_cpu_req": cfg.get('configs.couchdb.resources.cpu-req') or "1",
-        "container_cpu_lim": cfg.get('configs.couchdb.resources.cpu-lim') or "2",
+        "container_cpu_req": cfg.get('configs.couchdb.resources.cpu-req') or "500m",
+        "container_cpu_lim": cfg.get('configs.couchdb.resources.cpu-lim') or "1",
         "container_mem_req": cfg.get('configs.couchdb.resources.mem-req') or "1G",
-        "container_mem_lim": cfg.get('configs.couchdb.resources.mem-lim') or "2G"
+        "container_mem_lim": cfg.get('configs.couchdb.resources.mem-lim') or "2G",
+        "container_manage_resources": cfg.exists('configs.couchdb.resources.cpu-req')
     }
 
     kus.processTemplate("couchdb","couchdb-set-tpl.yaml",data,"couchdb-set_generated.yaml")

--- a/nuvolaris/templates/couchdb-set-tpl.yaml
+++ b/nuvolaris/templates/couchdb-set-tpl.yaml
@@ -47,6 +47,7 @@ spec:
         {% else %}
         imagePullPolicy: "IfNotPresent"
         {% endif %}
+        {% if container_manage_resources %}
         resources:
           requests:
             memory: "{{container_mem_req}}"
@@ -54,6 +55,7 @@ spec:
           limits:
             memory: "{{container_mem_lim}}"
             cpu : "{{container_cpu_lim}}"
+        {% endif %}
         ports:
         - name: couchdb
           containerPort: 5984

--- a/nuvolaris/templates/standalone-sts.yaml
+++ b/nuvolaris/templates/standalone-sts.yaml
@@ -73,13 +73,15 @@ spec:
           capabilities:
             drop:
             - ALL
+        {% if container_manage_resources %}
         resources:
           requests:
             memory: "{{container_mem_req}}"
             cpu : "{{container_cpu_req}}"
           limits:
             memory: "{{container_mem_lim}}"
-            cpu : "{{container_cpu_lim}}"            
+            cpu : "{{container_cpu_lim}}"
+        {% endif %}
         env:
 
         - name: "PORT"

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -145,10 +145,11 @@ def get_standalone_config_data():
         "concurrency_limit_std": cfg.get("configs.limits.concurrency.limit-std") or 1, 
         "concurrency_limit_max": cfg.get("configs.limits.concurrency.limit-max") or 1,
         "controller_java_opts": cfg.get('configs.controller.javaOpts') or "-Xmx2048M",
-        "container_cpu_req": cfg.get('configs.controller.resources.cpu-req') or "1",
-        "container_cpu_lim": cfg.get('configs.controller.resources.cpu-lim') or "2",
+        "container_cpu_req": cfg.get('configs.controller.resources.cpu-req') or "500m",
+        "container_cpu_lim": cfg.get('configs.controller.resources.cpu-lim') or "1",
         "container_mem_req": cfg.get('configs.controller.resources.mem-req') or "1G",
-        "container_mem_lim": cfg.get('configs.controller.resources.mem-lim') or "2G"
+        "container_mem_lim": cfg.get('configs.controller.resources.mem-lim') or "2G",
+        "container_manage_resources": cfg.exists('configs.controller.resources.cpu-req')
     }
     return data
 

--- a/tests/kind/whisk.yaml
+++ b/tests/kind/whisk.yaml
@@ -79,17 +79,17 @@ spec:
         fires-perMinute: 999
     controller:
       javaOpts: "-Xmx2048M"
-      resources:
-        cpu-req: "1"
-        cpu-lim: "2"
-        mem-req: "1G"
-        mem-lim: "2G"
-    couchdb:
-      resources:
-        cpu-req: "1"
-        cpu-lim: "2"
-        mem-req: "512M"
-        mem-lim: "1G"        
+      #resources:
+      #  cpu-req: "500m"
+      #  cpu-lim: "1"
+      #  mem-req: "1G"
+      #  mem-lim: "2G"
+    #couchdb:
+      #resources:
+        #cpu-req: "500m"
+        #cpu-lim: "1"
+        #mem-req: "512M"
+        #mem-lim: "1G"        
   redis:
     volume-size: 10
     default:


### PR DESCRIPTION
feature: setup couchdb and controller container resources only if cor…responding spec configuration is defined