### PR TITLE
Implements nuvolaris/nuvolaris#235

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ ADD deploy/nginx-static /home/nuvolaris/deploy/nginx-static
 ADD deploy/content /home/nuvolaris/deploy/content
 ADD deploy/postgres-operator /home/nuvolaris/deploy/postgres-operator
 ADD deploy/postgres-operator-deploy /home/nuvolaris/deploy/postgres-operator-deploy
+ADD deploy/ferretdb /home/nuvolaris/deploy/ferretdb
 ADD run.sh dbinit.sh cron.sh pyproject.toml poetry.lock whisk-system.sh /home/nuvolaris/
 
 # prepares the required folders to deploy the whisk-system actions

--- a/TaskfileTest.yml
+++ b/TaskfileTest.yml
@@ -30,7 +30,6 @@ vars:
   WHISK: '{{default "whisk" .WHISK}}'
   CONFIG: "tests/{{.KUBE}}/{{.WHISK}}.yaml"
   REDIS_URI: "redis://default:s0meP@ass3@redis:6379"
-  MONGO_URI: "mongodb://nuvolaris:s0meP%40ass3@nuvolaris-mongodb-0.nuvolaris-mongodb-svc.nuvolaris.svc.cluster.local:27017/nuvolaris?connectTimeoutMS=60000"
   POSTGRES_URI: "postgresql://nuvolaris:s0meP%40ass3@nuvolaris-postgres.nuvolaris.svc.cluster.local:5432/nuvolaris"
   MINIO_HOST: "minio"
   MINIO_PORT: 9000
@@ -158,7 +157,9 @@ tasks:
     - wsk -i action invoke api -r | grep '"api"'
 
   mongo:
-    - wsk -i package update mongo -p dburi {{.MONGO_URI}}
+    - | 
+       MONGODB_URL=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.mongodb_url}') 
+       wsk -i package update mongo -p dburi "$MONGODB_URL"
     - wsk -i action update mongo/mongo tests/mongo.js
     - wsk -i action invoke mongo/mongo -r | grep "hello"
 

--- a/TaskfileTest.yml
+++ b/TaskfileTest.yml
@@ -30,7 +30,6 @@ vars:
   WHISK: '{{default "whisk" .WHISK}}'
   CONFIG: "tests/{{.KUBE}}/{{.WHISK}}.yaml"
   REDIS_URI: "redis://default:s0meP@ass3@redis:6379"
-  POSTGRES_URI: "postgresql://nuvolaris:s0meP%40ass3@nuvolaris-postgres.nuvolaris.svc.cluster.local:5432/nuvolaris"
   MINIO_HOST: "minio"
   MINIO_PORT: 9000
   MINIO_USER: "minioadmin"
@@ -172,7 +171,9 @@ tasks:
     - wsk -i project deploy --manifest tests/mongo.yaml
 
   postgres:
-    - wsk -i package update postgres -p dburi {{.POSTGRES_URI}}
+    - |
+      PG_URL=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.postgres_url}')
+      wsk -i package update postgres -p dburi "$PG_URL"
     - wsk -i action update postgres/postgres tests/postgres.js
     - wsk -i action invoke postgres/postgres -r | grep "Nuvolaris Postgres is up and running!"
 

--- a/deploy/ferretdb/ferretdb-sts.yaml
+++ b/deploy/ferretdb/ferretdb-sts.yaml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: nuvolaris-mongodb
+  labels:
+    app: mongodb
+  namespace: nuvolaris 
+spec:
+  serviceName: nuvolaris-mongodb-svc
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nuvolaris-mongodb
+  template:
+    metadata:
+      annotations:
+        whisks.nuvolaris.org/annotate-version: "true"     
+      labels:
+        app: nuvolaris-mongodb
+        name: nuvolaris-mongodb
+    spec:
+      containers:
+      - image: ghcr.io/ferretdb/ferretdb:1.6.0
+        name: ferretdb
+        env:
+        - name: FERRETDB_POSTGRESQL_URL
+          value: postgresql://nuvolaris:s0meP%40ass3@nuvolaris-postgres.nuvolaris.svc.cluster.local:5432/nuvolaris

--- a/deploy/ferretdb/ferretdb-svc.yaml
+++ b/deploy/ferretdb/ferretdb-svc.yaml
@@ -1,0 +1,31 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nuvolaris-mongodb-svc
+  namespace: nuvolaris
+spec:
+  clusterIP: None
+  ports:   
+    - port: 27017
+      targetPort: 27017
+  selector:
+    app: nuvolaris-mongodb
+    statefulset.kubernetes.io/pod-name: nuvolaris-mongodb-0

--- a/nuvolaris/ferretdb.py
+++ b/nuvolaris/ferretdb.py
@@ -1,0 +1,202 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+# Deploys a standalone ferretdb relying on postgres db
+#
+
+import kopf, json, time
+import nuvolaris.kube as kube
+import nuvolaris.kustomize as kus
+import nuvolaris.config as cfg
+import nuvolaris.util as util
+import nuvolaris.postgres_operator as postgres
+import logging
+import nuvolaris.openwhisk as openwhisk
+import urllib.parse
+
+from nuvolaris.user_config import UserConfig
+from nuvolaris.user_metadata import UserMetadata
+
+def create(owner=None):
+    """
+    Deploys ferret db and wait for the pod to be ready.
+    """
+    logging.info("*** creating ferretdb")
+
+    data = util.get_postgres_config_data()
+    # use nuvolari spostgresdb as default user
+    data['ferretdb_postgres_url']=util.get_value_from_config_map(path='{.metadata.annotations.postgres_url}')
+
+    mkust = kus.patchTemplates("ferretdb", ["ferretdb-sts.yaml"], data)    
+    mspec = kus.kustom_list("ferretdb", mkust, templates=[], data=data)
+
+    if owner:
+        kopf.append_owner_reference(mspec['items'], owner)
+    else:
+        cfg.put("state.ferretdb.spec", mspec)
+    
+    res = kube.apply(mspec)
+
+    # dynamically detect mongodb pod and wait for readiness
+    if res:
+        util.wait_for_pod_ready("{.items[?(@.metadata.labels.app == 'nuvolaris-mongodb')].metadata.name}")
+        update_system_cm_for_mdb(data)
+        logging.info("*** created ferretdb")
+        
+    return res
+
+def get_ferret_pod_name():
+    return util.get_pod_name("{.items[?(@.metadata.labels.app == 'nuvolaris-mongodb')].metadata.name}")    
+
+def update_system_cm_for_mdb(data):
+    logging.info("*** annotating configuration for ferretdb nuvolaris user")
+    try:        
+        mdb_service = util.get_service("{.items[?(@.metadata.name == 'nuvolaris-mongodb-svc')]}")
+        if(mdb_service):
+            mdb_pod_name = get_ferret_pod_name()        
+            mdb_service_name = mdb_service['metadata']['name']            
+            mdb_ns = mdb_service['metadata']['namespace']
+
+            data = util.get_postgres_config_data()
+
+            username = urllib.parse.quote(data['postgres_nuvolaris_user'])
+            password = urllib.parse.quote(data['postgres_nuvolaris_password'])
+            auth = f"{username}:{password}"
+            
+            mdb_url = f"mongodb://{auth}@{mdb_pod_name}.{mdb_service_name}.{mdb_ns}.svc.cluster.local:27017/nuvolaris?connectTimeoutMS=60000&authMechanism=PLAIN"
+            openwhisk.annotate(f"mongodb_url={mdb_url}")
+            logging.info("*** saved annotation for mongodb nuvolaris user")            
+    except Exception as e:
+        logging.error(f"failed to build mongodb_url for nuvolaris database: {e}")  
+
+def delete_by_owner():
+    spec = kus.build("ferretdb")
+    res = kube.delete(spec)
+    logging.info(f"delete ferretdb: {res}")
+    return res
+
+def delete_by_spec():
+    spec = cfg.get("state.ferretdb.spec")
+    res = False
+    if spec:
+        res = kube.delete(spec)
+        logging.info(f"delete ferretdb: {res}")
+    
+    return res
+
+def delete(owner=None):
+    if owner:        
+        return delete_by_owner()
+    else:
+        return delete_by_spec()
+
+def patch(status, action, owner=None):
+    """
+    Called the the operator patcher to create/delete ferredb
+    """
+    try:
+        logging.info(f"*** handling request to {action} ferretdb")  
+        if  action == 'create':
+            msg = create(owner)
+            status['whisk_create']['ferretdb']='on'
+        else:
+            msg = delete(owner)
+            status['whisk_create']['ferretdb']='off'
+
+        logging.info(msg)        
+        logging.info(f"*** handled request to {action} ferretdb") 
+    except Exception as e:
+        logging.error('*** failed to update ferretdb: %s' % e)
+        status['whisk_create']['ferretdb']='error'             
+
+def _add_mdb_user_metadata(user_metadata, data):
+    """
+    adds an entry for the mongodb connectivity, i.e
+    something like "mongodb://{namespace}:{auth}@nuvolaris-mongodb-0.nuvolaris-mongodb-svc.nuvolaris.svc.cluster.local:27017/{database}?connectTimeoutMS=60000"}
+    """ 
+
+    try:
+        mdb_service = util.get_service("{.items[?(@.metadata.name == 'nuvolaris-mongodb-svc')]}")
+
+        if(mdb_service):
+            mdb_service_name = mdb_service['metadata']['name']            
+            mdb_ns = mdb_service['metadata']['namespace']
+            mdb_pod_name = get_ferret_pod_name()
+
+            username = urllib.parse.quote(data["username"])
+            password = urllib.parse.quote(data["password"])
+            auth = f"{username}:{password}"            
+            database = data["database"]
+
+            mdb_url = f"mongodb://{auth}@{mdb_pod_name}.{mdb_service_name}.{mdb_ns}.svc.cluster.local:27017/{database}?connectTimeoutMS=60000&authMechanism=PLAIN"
+            user_metadata.add_metadata("MONGODB_URL",mdb_url)
+        return None
+    except Exception as e:
+        logging.error(f"failed to build mongodb_url for {ucfg.get('mongodb.database')}: {e}")
+        return None
+
+def create_db_user(ucfg: UserConfig, user_metadata: UserMetadata):
+    database = ucfg.get('mongodb.database')
+    subject = ucfg.get('namespace')
+    namespace = ucfg.get('namespace')
+    logging.info(f"authorizing new ferretdb database {database}")
+
+    try:
+        data = util.get_postgres_config_data()
+        data["database"]=f"{database}_ferretdb"
+        data["username"]=f"{subject}_ferretdb"
+        data["password"]=ucfg.get('mongodb.password')
+        data["mode"]="create"
+        
+        path_to_pgpass = postgres.render_postgres_script(f"{namespace}_ferretdb","pgpass_tpl.properties",data)
+        path_to_mdb_script = postgres.render_postgres_script(f"{namespace}_ferretdb","postgres_manage_user_tpl.sql",data)
+        pod_name = util.get_pod_name("{.items[?(@.metadata.labels.app == 'nuvolaris-postgres')].metadata.name}")      
+
+        if(pod_name):
+            res = postgres.exec_psql_command(pod_name,path_to_mdb_script,path_to_pgpass)
+
+            if(res):
+                _add_mdb_user_metadata(user_metadata, data)
+            return res
+
+        return None
+    except Exception as e:
+        logging.error(f"failed to add Mongodb database {database}: {e}")
+        return None
+
+def delete_db_user(namespace, database):
+    logging.info(f"removing ferretdb database {database}")
+
+    try:
+        data = util.get_postgres_config_data()        
+        data["database"]=f"{database}_ferretdb"
+        data["username"]=f"{namespace}_ferretdb"
+        data["mode"]="delete"
+
+        path_to_pgpass = postgres.render_postgres_script(f"{namespace}_ferretdb","pgpass_tpl.properties",data)
+        path_to_mdb_script = postgres.render_postgres_script(f"{namespace}_ferretdb","postgres_manage_user_tpl.sql",data)
+        pod_name = util.get_pod_name("{.items[?(@.metadata.labels.app == 'nuvolaris-postgres')].metadata.name}")
+
+        if(pod_name):
+            res = postgres.exec_psql_command(pod_name,path_to_mdb_script,path_to_pgpass)
+            return res 
+
+        return None
+    except Exception as e:
+        logging.error(f"failed to remove Ferretdb database {namespace} authorization id and key: {e}")
+        return None        

--- a/nuvolaris/main.py
+++ b/nuvolaris/main.py
@@ -25,7 +25,7 @@ import nuvolaris.couchdb as couchdb
 import nuvolaris.bucket as bucket
 import nuvolaris.openwhisk as openwhisk
 import nuvolaris.cronjob as cron
-import nuvolaris.mongodb as mongodb
+import nuvolaris.ferretdb as mongodb
 import nuvolaris.issuer as issuer
 import nuvolaris.endpoint as endpoint
 import nuvolaris.minio as minio
@@ -126,13 +126,6 @@ def whisk_create(spec, name, **kwargs):
     else:
         state['cron'] = "off" 
 
-    if cfg.get('components.mongodb'):
-        msg = mongodb.create(owner)
-        logging.info(msg)
-        state['mongodb'] = "on"
-    else:
-        state['mongodb'] = "off"
-
     if cfg.get('components.minio'):
         msg = minio.create(owner)
         logging.info(msg)
@@ -147,24 +140,19 @@ def whisk_create(spec, name, **kwargs):
     else:
         state['static'] = "off"
 
-    if cfg.get('components.postgres'):
+    if cfg.get('components.postgres') or cfg.get('components.mongodb'):
         msg = postgres.create(owner)
         logging.info(msg)
         state['postgres'] = "on"
     else:
-        state['postgres'] = "off"                 
-    
-    if cfg.get('components.kafka'):
-        logging.warn("invoker not yet implemented")
-        state['kafka'] = "n/a"
-    else:
-        state['kafka'] = "off"
+        state['postgres'] = "off"
 
-    if cfg.get('components.invoker'):
-        logging.warn("invoker not yet implemented")
-        state['invoker'] = "n/a"
+    if cfg.get('components.mongodb'):
+        msg = mongodb.create(owner)
+        logging.info(msg)
+        state['mongodb'] = "on"
     else:
-        state['invoker'] = "off"        
+        state['mongodb'] = "off"                        
 
     if cfg.get('components.openwhisk'):
         try:

--- a/nuvolaris/patcher.py
+++ b/nuvolaris/patcher.py
@@ -17,7 +17,7 @@
 #
 import logging, time
 import nuvolaris.openwhisk as openwhisk
-import nuvolaris.mongodb as mongodb
+import nuvolaris.ferretdb as mongodb
 import nuvolaris.redis as redis
 import nuvolaris.cronjob as cron
 import nuvolaris.minio as minio
@@ -90,6 +90,10 @@ def patch(diff, status, owner=None):
     components_updated = False    
 
     # components 1st
+    if "postgres" in what_to_do:
+        postgres.patch(status,what_to_do['postgres'], owner)
+        components_updated = True
+
     if "mongodb" in what_to_do:
         mongodb.patch(status,what_to_do['mongodb'], owner)
         components_updated = True
@@ -108,10 +112,6 @@ def patch(diff, status, owner=None):
 
     if "static" in what_to_do:
         static.patch(status,what_to_do['static'], owner)
-        components_updated = True 
-
-    if "postgres" in what_to_do:
-        postgres.patch(status,what_to_do['postgres'], owner)
         components_updated = True
 
     # handle update action on openwhisk
@@ -125,7 +125,7 @@ def patch(diff, status, owner=None):
         endpoint.patch(status,what_to_do['endpoint'], owner)
 
     if components_updated:
-        version_util.annotate_operator_components_version()          
+        version_util.annotate_operator_components_version()         
     
         
     

--- a/nuvolaris/postgres_operator.py
+++ b/nuvolaris/postgres_operator.py
@@ -114,6 +114,23 @@ def update_system_cm_for_pdb(data):
     except Exception as e:
         logging.error(f"failed to build postgres data for nuvolaris database: {e}")
 
+def get_base_postgres_url(data):    
+    try:        
+        pdb_service = util.get_service("{.items[?(@.metadata.labels.replicationRole == 'primary')]}")
+        if(pdb_service):             
+            pdb_service_name = pdb_service['metadata']['name']
+            pdb_ns = pdb_service['metadata']['namespace']
+            pdb_host = f"{pdb_service_name}.{pdb_ns}.svc.cluster.local"            
+            pdb_port = pdb_service['spec']['ports'][0]['port']
+            username = "nuvolaris"
+            database = "nuvolaris"
+            password = urllib.parse.quote(data['postgres_nuvolaris_password'])
+            auth = f"{username}:{password}"            
+            return f"postgresql://{auth}@{pdb_service_name}.{pdb_ns}.svc.cluster.local:{pdb_port}"
+           
+    except Exception as e:
+        logging.error(f"failed to build base postgres URL: {e}")        
+
 def _add_pdb_user_metadata(ucfg, user_metadata):
     """
     adds an entry for the postgres connectivity, i.e   

--- a/nuvolaris/templates/ferretdb-sts.yaml
+++ b/nuvolaris/templates/ferretdb-sts.yaml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: nuvolaris-mongodb
+  labels:
+    app: mongodb
+  namespace: nuvolaris
+spec:
+  serviceName: nuvolaris-mongodb-svc
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nuvolaris-mongodb
+  template:
+    metadata:
+      annotations:
+        whisks.nuvolaris.org/annotate-version: "true" 
+      labels:
+        app: nuvolaris-mongodb
+        name: nuvolaris-mongodb         
+    spec:
+      containers:
+      - image: ghcr.io/ferretdb/ferretdb:1.6.0
+        name: ferretdb
+        env:
+        - name: FERRETDB_POSTGRESQL_URL
+          value: {{ferretdb_postgres_url}}          

--- a/nuvolaris/templates/postgres_manage_user_tpl.sql
+++ b/nuvolaris/templates/postgres_manage_user_tpl.sql
@@ -24,6 +24,12 @@ GRANT ALL PRIVILEGES ON DATABASE {{database}} to {{username}};
 {% endif %}
 
 {% if mode == 'delete' %}
+SELECT pg_terminate_backend(pg_stat_activity.pid)
+FROM pg_stat_activity
+WHERE pg_stat_activity.datname = '{{database}}';
+
 DROP DATABASE {{database}};
+
+DROP OWNED BY {{username}};
 DROP USER {{username}};
 {% endif %}

--- a/nuvolaris/user_handlers.py
+++ b/nuvolaris/user_handlers.py
@@ -23,7 +23,7 @@ import nuvolaris.config as cfg
 import nuvolaris.couchdb as cdb
 import nuvolaris.minio as minio
 import nuvolaris.kube as kube
-import nuvolaris.mongodb as mdb
+import nuvolaris.ferretdb as mdb
 import nuvolaris.minio_static as static
 import nuvolaris.redis as redis
 import nuvolaris.userdb_util as userdb
@@ -63,7 +63,7 @@ def whisk_user_create(spec, name, **kwargs):
     if(cfg.get('components.mongodb') and ucfg.get('mongodb.enabled')):
         res = mdb.create_db_user(ucfg,user_metadata)
         logging.info(f"Mongodb setup for {ucfg.get('namespace')} added = {res}")
-        state['mongodb']= res  
+        state['mongodb']= res
 
     if(cfg.get('components.redis') and ucfg.get('redis.enabled')):
         res = redis.create_db_user(ucfg, user_metadata)

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -258,4 +258,11 @@ def get_apihost_from_config_map(namespace="nuvolaris"):
     if(annotations):
         return annotations[0]
 
-    raise Exception("Could not find apihost annotation inside internal cm/config config Map")                              
+    raise Exception("Could not find apihost annotation inside internal cm/config config Map")  
+
+def get_value_from_config_map(namespace="nuvolaris", path='{.metadata.annotations.apihost}'):
+    annotations= kube.kubectl("get", "cm/config", namespace=namespace, jsonpath=path)
+    if(annotations):
+        return annotations[0]
+
+    raise Exception("Could not find annotation inside internal cm/config config Map")                                  

--- a/tests/kind/ferretdb_test.ipy
+++ b/tests/kind/ferretdb_test.ipy
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all
+
+import nuvolaris.config as cfg
+import nuvolaris.testutil as tu
+import nuvolaris.kube as kube
+import nuvolaris.ferretdb as mdb
+import nuvolaris.postgres_operator as postgres
+import logging
+
+# test
+assert(cfg.configure(tu.load_sample_config()))
+cfg.detect_storage()
+assert(postgres.create())
+assert(mdb.create())
+
+while not kube.wait("pod/nuvolaris-mongodb-0", "condition=ready"): pass
+
+assert(kube.get("service/nuvolaris-mongodb-svc"))
+assert(kube.kubectl("get", f"cm/config", jsonpath="{.metadata.annotations.mongodb_url}"))
+assert(mdb.delete())
+assert(postgres.delete())
+
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all


### PR DESCRIPTION
This PR adds ferretDB as a complete replacement of MongoDB operator/standalone deployer keeping the whisk.crd and configuration parameters as they are currently defined for mongodb.

Internally FerretDB relies on a PostgresSQL database, therefore it is necessary to have it deployed even if it is not enabled in the configuration.