### PR TITLE
Fix nuvolaris/nuvolaris#241

### DIFF
--- a/deploy/nuvolaris-permissions/whisk-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-crd.yaml
@@ -60,7 +60,19 @@ spec:
                       - https
                     kube:
                       description: label representing the kubernetes runtime used to implement specific logic (kind, eks, aks, lks, microk8s, k3s, openshift). Defaulted to detect which is causing the operator to autodetect the k8s runtime.
-                      type: string                     
+                      type: string
+                    storageclass:
+                      description: allow to set a defined storage class. Default to auto which will force the operator to autodetect the storage class.
+                      type: string
+                    provisioner:
+                      description: allow to set a defined storage class provisioner. Default to auto which will force the operator to autodetect the storage class provisioner.
+                      type: string                      
+                    ingressclass:
+                      description: allow to set a defined ingress class. Default to auto which will force the operator to autodetect the ingress class.
+                      type: string
+                    ingresslb:
+                      description: allow to set the location of the ingress lb in the form namespace/service-name. Default to auto which will force the operator to use default values based on the environment.
+                      type: string                                                                   
                 components:
                   description: it allows which components needs to be deployed by default. For a minimal setup openwhisk and couchdb are required to be set to true
                   type: object

--- a/nuvolaris/apihost_util.py
+++ b/nuvolaris/apihost_util.py
@@ -68,8 +68,8 @@ def to_ingress_ip(machine_ip_str):
     """
     return [{"ip":machine_ip_str}]
 
-def get_ingress(namespace="ingress-nginx"):
-    ingress = kube.kubectl("get", "service/ingress-nginx-controller", namespace=namespace,jsonpath="{.status.loadBalancer.ingress[0]}")
+def get_ingress(namespace="ingress-nginx",ingress_srv_name="service/ingress-nginx-controller"):
+    ingress = kube.kubectl("get", ingress_srv_name, namespace=namespace,jsonpath="{.status.loadBalancer.ingress[0]}")
     if ingress:
         return ingress
     
@@ -119,7 +119,9 @@ def get_apihost(runtime_str):
             apihost = calculate_apihost(runtime_str,None)
     else:
         namespace = util.get_ingress_namespace(runtime_str)
-        apihost = calculate_apihost(runtime_str,get_ingress(namespace))
+        ingress_srv_name = util.get_ingress_service_name(runtime_str)
+        
+        apihost = calculate_apihost(runtime_str,get_ingress(namespace, ingress_srv_name))
 
     return apihost
 

--- a/nuvolaris/couchdb.py
+++ b/nuvolaris/couchdb.py
@@ -58,7 +58,7 @@ def create(owner=None):
         "name": "couchdb", 
         "size": cfg.get("couchdb.volume-size", "COUCHDB_VOLUME_SIZE", 10), 
         "dir": "/opt/couchdb/data",
-        "storageClass": cfg.get("nuvolaris.storageClass"),
+        "storageClass": cfg.get("nuvolaris.storageclass"),
         "container_cpu_req": cfg.get('configs.couchdb.resources.cpu-req') or "500m",
         "container_cpu_lim": cfg.get('configs.couchdb.resources.cpu-lim') or "1",
         "container_mem_req": cfg.get('configs.couchdb.resources.mem-req') or "1G",

--- a/nuvolaris/endpoint.py
+++ b/nuvolaris/endpoint.py
@@ -25,10 +25,10 @@ import nuvolaris.apihost_util as apihost_util
 import urllib.parse
 import nuvolaris.time_util as tutil
 
-def get_ingress_data(apihost, tls):
+def get_ingress_data(runtime, apihost, tls):
     url = urllib.parse.urlparse(apihost)
     hostname = url.hostname    
-    ingress_class = cfg.detect_ingress_class()
+    ingress_class = util.get_ingress_class(runtime)
 
     data = {
         "hostname":hostname,
@@ -43,10 +43,10 @@ def get_ingress_data(apihost, tls):
 
     return data
 
-def get_osh_data(apihost, tls):
+def get_osh_data(runtime, apihost, tls):
     url = urllib.parse.urlparse(apihost)
     hostname = url.hostname    
-    ingress_class = cfg.detect_ingress_class()
+    ingress_class = util.get_ingress_class(runtime)
 
     data = {
         "hostname":hostname,
@@ -85,7 +85,7 @@ def create(owner=None):
     openwhisk.annotate(f"apihost={apihost}")
     cfg.put("config.apihost", apihost)
 
-    data = runtime=='openshift' and get_osh_data(apihost, tls) or get_ingress_data(apihost, tls)    
+    data = runtime=='openshift' and get_osh_data(runtime, apihost, tls) or get_ingress_data(runtime, apihost, tls)    
     assign_route_timeout(data)
 
     spec = runtime=='openshift' and create_osh_route_spec(data) or create_ingress_route_spec(data)

--- a/tests/config_test.ipy
+++ b/tests/config_test.ipy
@@ -29,13 +29,14 @@ assert(cfg.get("g") == 5)
 
 assert(len(cfg.getall("a")) == 4)
 assert(len(cfg.getall("a.c")) == 2)
-assert(len(cfg.keys()) == 5)
+assert(len(cfg.keys()) == 6)
 assert(len(cfg.keys("a.c")) == 2)
 
 
 assert(cfg.configure({"a":1}))
 assert(cfg.get("a") == 1 )
 labels = [{"nuvolaris.io/hello": "world", "something": "else" }, {}, {"nothing":"here"}]
+cfg.delete("nuvolaris.kube")
 cfg.detect_labels(labels)
 assert(cfg.get("nuvolaris.hello") == "world")
 assert(cfg.get("nuvolaris.kube") == "generic")

--- a/tests/eks/config_test.ipy
+++ b/tests/eks/config_test.ipy
@@ -20,4 +20,4 @@ import nuvolaris.kube as kube
 
 cfg.clean()
 assert(cfg.detect_labels()['nuvolaris.kube']=="eks")
-assert(cfg.detect_storage()["nuvolaris.storageClass"]=="gp2")
+assert(cfg.detect_storage()["nuvolaris.storageclass"]=="gp2")

--- a/tests/k3s/config_test.ipy
+++ b/tests/k3s/config_test.ipy
@@ -20,4 +20,4 @@ import nuvolaris.kube as kube
 
 cfg.clean()
 assert(cfg.detect_labels()['nuvolaris.kube'] == "k3s")
-assert(cfg.detect_storage()['nuvolaris.storageClass'] in ["local-path"])
+assert(cfg.detect_storage()['nuvolaris.storageclass'] in ["local-path"])

--- a/tests/kind/config_test.ipy
+++ b/tests/kind/config_test.ipy
@@ -24,7 +24,7 @@ import requests as req
 #print("kind")
 cfg.clean()
 assert(cfg.detect_labels()['nuvolaris.kube'] == "kind")
-assert(cfg.detect_storage()['nuvolaris.storageClass'] == "standard")
+assert(cfg.detect_storage()['nuvolaris.storageclass'] == "standard")
 
 # check hostpath
 cfg.configure(tu.load_sample_config())

--- a/tests/kind/couchdb_lib_test.ipy
+++ b/tests/kind/couchdb_lib_test.ipy
@@ -29,7 +29,7 @@ import requests as req
 assert(cfg.configure(tu.load_sample_config()))
 cfg.put("couchdb.host", "localhost")
 assert(cfg.detect_labels()["nuvolaris.kube"] == "kind")
-assert(cfg.detect_storage()["nuvolaris.storageClass"] == "standard")
+assert(cfg.detect_storage()["nuvolaris.storageclass"] == "standard")
 assert(cfg.get("couchdb.host") == "localhost")
 
 !kubectl apply -f tests/kind/whisk.yaml

--- a/tests/kind/minio_static_test.ipy
+++ b/tests/kind/minio_static_test.ipy
@@ -28,7 +28,7 @@ import os
 
 # test
 assert(cfg.configure(tu.load_sample_config()))
-assert(cfg.detect_storage()["nuvolaris.storageClass"])
+assert(cfg.detect_storage()["nuvolaris.storageclass"])
 
 # for this test minioClient should see this env variable
 os.environ['MINIO_API_HOST']='localhost'

--- a/tests/kind/minio_test.ipy
+++ b/tests/kind/minio_test.ipy
@@ -29,7 +29,7 @@ import logging, os
 
 # test
 assert(cfg.configure(tu.load_sample_config()))
-assert(cfg.detect_storage()["nuvolaris.storageClass"])
+assert(cfg.detect_storage()["nuvolaris.storageclass"])
 
 # for this test minioClient should see this env variable
 os.environ['MINIO_API_HOST']='localhost'

--- a/tests/kind/minio_util_test.ipy
+++ b/tests/kind/minio_util_test.ipy
@@ -30,7 +30,7 @@ import logging, os
 
 # test
 assert(cfg.configure(tu.load_sample_config()))
-assert(cfg.detect_storage()["nuvolaris.storageClass"])
+assert(cfg.detect_storage()["nuvolaris.storageclass"])
 
 os.environ['MINIO_API_HOST']='localhost'
 assert(minio.create())

--- a/tests/kind/nuvolaris_subject_test.ipy
+++ b/tests/kind/nuvolaris_subject_test.ipy
@@ -32,7 +32,7 @@ from kopf.testing import KopfRunner
 
 assert(cfg.configure(tu.load_sample_config()))
 assert(cfg.detect_labels()["nuvolaris.kube"] == "kind")
-assert(cfg.detect_storage()["nuvolaris.storageClass"] == "standard")
+assert(cfg.detect_storage()["nuvolaris.storageclass"] == "standard")
 assert(cfg.put("couchdb.host", "localhost"))
 
 !kubectl apply -f tests/kind/whisk.yaml

--- a/tests/kind/userdb_util_test.ipy
+++ b/tests/kind/userdb_util_test.ipy
@@ -31,7 +31,7 @@ import nuvolaris.user_metadata as user_metadata
 
 assert(cfg.configure(tu.load_sample_config()))
 assert(cfg.detect_labels()["nuvolaris.kube"] == "kind")
-assert(cfg.detect_storage()["nuvolaris.storageClass"] == "standard")
+assert(cfg.detect_storage()["nuvolaris.storageclass"] == "standard")
 assert(cfg.put("couchdb.host", "localhost"))
 
 !kubectl apply -f tests/kind/whisk.yaml

--- a/tests/kind/whisk.yaml
+++ b/tests/kind/whisk.yaml
@@ -48,6 +48,11 @@ spec:
     namespaces:
       whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
       nuvolaris: cbd68075-dac2-475e-8c07-d62a30c7e683:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
+  nuvolaris:
+    storageclass: auto #standard
+    provisioner: auto #rancher.io/local-path
+    ingressclass: auto #nginx
+    ingresslb: auto #ingress-nginx/ingress-nginx-controller
   couchdb:
     host: couchdb
     port: 5984

--- a/tests/lks/config_test.ipy
+++ b/tests/lks/config_test.ipy
@@ -20,5 +20,5 @@ import nuvolaris.kube as kube
 
 cfg.clean()
 assert(cfg.detect_labels()['nuvolaris.kube'] == "lks")
-assert(cfg.detect_storage()['nuvolaris.storageClass'] == "linode-block-storage-retain")
+assert(cfg.detect_storage()['nuvolaris.storageclass'] == "linode-block-storage-retain")
 

--- a/tests/microk8s/config_test.ipy
+++ b/tests/microk8s/config_test.ipy
@@ -20,4 +20,4 @@ import nuvolaris.kube as kube
 
 cfg.clean()
 assert(cfg.detect_labels()['nuvolaris.kube'] == "microk8s")
-assert(cfg.detect_storage()['nuvolaris.storageClass'] in ["microk8s-hostpath", "mayastor", "mayastor-3"])
+assert(cfg.detect_storage()['nuvolaris.storageclass'] in ["microk8s-hostpath", "mayastor", "mayastor-3"])

--- a/tests/volume_test.ipy
+++ b/tests/volume_test.ipy
@@ -37,7 +37,7 @@ assert(len(kube.get("pvc")["items"]) ==0)
 data = {"name": "test-nginx", 
         "size": "1", 
         "dir": "/usr/share/nginx/html",
-        "storageClass": cfg.get("nuvolaris.storageClass")
+        "storageClass": cfg.get("nuvolaris.storageclass")
 }
 #print(data)
 patch = kus.patchTemplate("test-sts", "set-attach.yaml", data) 


### PR DESCRIPTION
This PR adds support for these new non mandatory config parameter under whisk.crd nuvolaris key: storageclass, provisioner, ingressclass, ingresslb.

The default configuration which can be omitted from whisk.yaml it is equivalent to set

```
  nuvolaris:
    storageclass: auto 
    provisioner: auto
    ingressclass: auto
    ingresslb: auto
```

for kubernetes kind this is equivalent to configure nuvolaris using

```
  nuvolaris:
    storageclass: standard
    provisioner: rancher.io/local-path
    ingressclass: nginx
    ingresslb: ingress-nginx/ingress-nginx-controller
```

The parameter ingresslb, if set, must be of the form <ingress-namespace>/<ingress-nginx-controller-servicename>
