### PR TITLE
Improvement: adds lifecycle information to whisk-user deployed resources

### DIFF
--- a/nuvolaris/minio_static.py
+++ b/nuvolaris/minio_static.py
@@ -82,7 +82,7 @@ def prepare_static_ingress_data(ucfg, hostname):
     runtime = cfg.get('nuvolaris.kube')    
     bucket = ucfg.get('object-storage.route.bucket')
     tls = cfg.get('components.tls') and not runtime=='kind'
-    ingress_class = cfg.detect_ingress_class()
+    ingress_class = util.get_ingress_class(runtime)
     context_path = tls and "/" or f"/{bucket}"
     apply_traefik_prefix_middleware = ingress_class == 'traefik'
     apply_nginx_rewrite_rule = not apply_traefik_prefix_middleware
@@ -173,8 +173,8 @@ def create_ow_static_endpoint(ucfg, user_metadata: UserMetadata, owner=None):
 def delete_ow_static_endpoint(ucfg):
     namespace = ucfg.get("namespace")
     logging.info(f"*** removing static endpoint for {namespace}")
-    ingress_class = cfg.detect_ingress_class()
     runtime = cfg.get('nuvolaris.kube')
+    ingress_class = util.get_ingress_class(runtime)
     
     try:
         if(ingress_class == 'traefik'):            

--- a/tests/generic/whisk.yaml
+++ b/tests/generic/whisk.yaml
@@ -40,7 +40,7 @@ spec:
     # start cron based action parser
     cron: false
     # tls enabled or not
-    tls: false   
+    tls: true   
     # minio enabled or not
     minio: false
     # minio static enabled or not


### PR DESCRIPTION
This PR  adds condition status to whisk-user handlers to control deployment lifecycle. Which this improvement whisk-user deployed resources get this additional informations

```
status:
  conditions:
  - lastTransitionTime: "2023-07-25 22:24:03"
    status: "True"
    type: Initialized
  - lastTransitionTime: "2023-07-25 22:24:10"
    status: "True"
    type: Ready
```

which are giving the possibility too control wether a whisk-user custom resources has been deployed successfully using something like

`kubectl wait --for=condition=ready --timeout=60s -n nuvolaris wsku/franztt`