### PR TITLE
fix: improved kubegres operator readiness detection 

### DIFF
--- a/tests/eks/whisk.yaml
+++ b/tests/eks/whisk.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: nuvolaris
 spec:
   nuvolaris:
-      apihost: eks.sciabarra.net
+      apihost: nuvolaris.ftt.eks.n9s.cc
   components:
     # start openwhisk controller
     openwhisk: true
@@ -33,17 +33,17 @@ spec:
     # start kafka
     kafka: false
     # start mongodb
-    mongodb: true
+    mongodb: false
     # start redis
-    redis: true
+    redis: false
     # start cron based action parser
-    cron: true
+    cron: false
     # tls enabled or not
     tls: true
     # minio enabled or not
-    minio: true
+    minio: false
     # minio static enabled or not
-    static: true
+    static: false
     # postgres enabled or not
     postgres: true                      
   openwhisk:

--- a/tests/k3s/whisk-demo-user.yaml
+++ b/tests/k3s/whisk-demo-user.yaml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: nuvolaris.org/v1
+kind: WhiskUser
+metadata:
+  name: demo-postgres-user
+  namespace: nuvolaris
+spec:
+  auth: ba7e4790-444a-4094-8fe4-1ec2ad64931c:mdKKByEJQrR7wQrVkZirfGatwcKCSyuvBo5wyFMXZYMUtCfalk3yWLamkDsfFxUX
+  email: demo-postgres-user@email.com
+  mongodb:
+    database: demo-postgres-user
+    enabled: false
+    password: bD5F3RfA4NgR
+  namespace: demo-postgres-user
+  object-storage:
+    data:
+      bucket: demo-postgres-user-data
+      enabled: false
+    password: ugzGtF0005WH8o7nYgJuihze7XCgnPuc8b1cb7Rn
+    route:
+      bucket: demo-postgres-user-web
+      enabled: false
+  password: lZA6d8GHizTc
+  postgres:
+    database: demo-postgres-user
+    enabled: true
+    password: ief2mvpcWlTd
+  redis:
+    enabled: false
+    password: 4pd77bowP38s
+    prefix: demo-postgres-user


### PR DESCRIPTION
This PR contributes a fix to the kubegres deployment to verify the kubegres operator readiness which was failing under EKS and GKE clusters and therefore there was no postgres instance deployed.