### PR TITLE
feature: allow to specify custom controller image via spec.controller.image

### DIFF
--- a/nuvolaris/config.py
+++ b/nuvolaris/config.py
@@ -171,10 +171,19 @@ def detect_storage(storages=None):
 def detect_env():
     _config['operator.image'] = os.environ.get("OPERATOR_IMAGE", "missing-OPERATOR_IMAGE")
     _config['operator.tag'] = os.environ.get("OPERATOR_TAG", "missing-OPERATOR_TAG")
-    _config['controller.image'] = os.environ.get("CONTROLLER_IMAGE", "missing-CONTROLLER_IMAGE")
-    _config['controller.tag'] = os.environ.get("CONTROLLER_TAG", "missing-CONTROLLER_TAG")
-    _config['invoker.image'] = os.environ.get("INVOKER_IMAGE", "missing-INVOKER_IMAGE")
-    _config['invoker.tag'] = os.environ.get("INVOKER_TAG", "missing-INVOKER_TAG")
+
+    # skip autodetection of controller.image if already configure into whisk.yaml
+    if not exists('controller.image'):
+        _config['controller.image'] = os.environ.get("CONTROLLER_IMAGE", "missing-CONTROLLER_IMAGE")
+        _config['controller.tag'] = os.environ.get("CONTROLLER_TAG", "missing-CONTROLLER_TAG")
+    else:
+        logging.warn(f"OW controller image detection skipped. Using {get('controller.image')}")
+
+    if not exists('invoker.image'):
+        _config['invoker.image'] = os.environ.get("INVOKER_IMAGE", "missing-INVOKER_IMAGE")
+        _config['invoker.tag'] = os.environ.get("INVOKER_TAG", "missing-INVOKER_TAG")
+    else:
+        logging.warn(f"OW invoker image detection skipped. Using {get('invoker.image')}")
 
 def detect():
     detect_storage()

--- a/tests/config_test.ipy
+++ b/tests/config_test.ipy
@@ -36,7 +36,7 @@ assert(len(cfg.keys("a.c")) == 2)
 assert(cfg.configure({"a":1}))
 assert(cfg.get("a") == 1 )
 labels = [{"nuvolaris.io/hello": "world", "something": "else" }, {}, {"nothing":"here"}]
-cfg.delete("nuvolaris.kube")
+cfg.put("nuvolaris.kube","auto")
 cfg.detect_labels(labels)
 assert(cfg.get("nuvolaris.hello") == "world")
 assert(cfg.get("nuvolaris.kube") == "generic")

--- a/tests/kind/whisk.yaml
+++ b/tests/kind/whisk.yaml
@@ -48,6 +48,8 @@ spec:
     namespaces:
       whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
       nuvolaris: cbd68075-dac2-475e-8c07-d62a30c7e683:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
+#  controller:
+#    image: "ghcr.io/nuvolaris/openwhisk-controller:0.3.0-morpheus.22122609"    
   nuvolaris:
     storageclass: auto #standard
     provisioner: auto #rancher.io/local-path


### PR DESCRIPTION
This adds the possibility to specify OpenWhisk standalone controller image to be used using spec.controller.image entry on whisk.yaml overriding the environment variable provided in operator image.

Expected format is

`spec.controller.image:ghcr.io/nuvolaris/openwhisk-controller:0.3.0-morpheus.22122609
`