### PR TITLE
Implements nuvolaris/nuvolaris#246 and nuvolaris/nuvolaris#247

### DIFF
--- a/deploy/ferretdb/ferretdb-sts.yaml
+++ b/deploy/ferretdb/ferretdb-sts.yaml
@@ -37,7 +37,7 @@ spec:
         name: nuvolaris-mongodb
     spec:
       containers:
-      - image: ghcr.io/ferretdb/ferretdb:1.6.0
+      - image: ghcr.io/nuvolaris/ferretdb:1.6.0
         name: ferretdb
         env:
         - name: FERRETDB_POSTGRESQL_URL

--- a/deploy/minio/01-minio-dep.yaml
+++ b/deploy/minio/01-minio-dep.yaml
@@ -41,7 +41,7 @@ spec:
           claimName: minio-pv-claim
       containers:
       - name: minio
-        image: quay.io/minio/minio:RELEASE.2023-03-24T21-41-23Z
+        image: bitnami/minio:2023.3.24
         command:
         - /bin/bash
         - -c

--- a/deploy/redis/redis-set.yaml
+++ b/deploy/redis/redis-set.yaml
@@ -37,16 +37,13 @@ spec:
       restartPolicy: Always  
       containers:
       - name: redis
-        image: redis:7.0.10
+        image: bitnami/redis:7.0.10
         command: ["/bin/sh","-c","redis-server /redis-master/redis.conf"]
         env:
         - name: MASTER
           value: "true"
         ports:
         - containerPort: 6379
-        #resources:
-        #  limits:
-        #    cpu: "0.1"
         volumeMounts:
         - mountPath: /redis-master
           name: config

--- a/nuvolaris/couchdb.py
+++ b/nuvolaris/couchdb.py
@@ -56,6 +56,7 @@ def create(owner=None):
         "image": image,
         "config": config,
         "name": "couchdb", 
+        "container": "couchdb", 
         "size": cfg.get("couchdb.volume-size", "COUCHDB_VOLUME_SIZE", 10), 
         "dir": "/opt/couchdb/data",
         "storageClass": cfg.get("nuvolaris.storageclass"),

--- a/nuvolaris/kustomize.py
+++ b/nuvolaris/kustomize.py
@@ -179,7 +179,7 @@ def patchTemplate(where, template, data):
     """   
     >>> import nuvolaris.testutil as tu
     >>> import os.path
-    >>> data = {"name":"test-pod", "dir":"/usr/share/nginx/html"}
+    >>> data = {"name":"test-pod", "container":"test-pod", "dir":"/usr/share/nginx/html"}
     >>> print(patchTemplate("test",  "set-attach.yaml", data), end='')
     patches:
     - path: __set-attach.yaml
@@ -197,7 +197,7 @@ def patchTemplates(where, templates=[], data={}):
     """   
     >>> import nuvolaris.testutil as tu
     >>> import os.path
-    >>> data = {"name":"test-pod", "dir":"/usr/share/nginx/html"}
+    >>> data = {"name":"test-pod", "container":"test-pod","dir":"/usr/share/nginx/html"}
     >>> print(patchTemplates("test",  ["set-attach.yaml","cron-init.yaml"], data), end='')
     patches:
     - path: __set-attach.yaml

--- a/nuvolaris/minio.py
+++ b/nuvolaris/minio.py
@@ -58,9 +58,16 @@ def find_content_path(filename):
 
 def create(owner=None):
     logging.info(f"*** configuring minio standalone")
+    runtime = cfg.get('nuvolaris.kube')
 
-    data = util.get_minio_config_data()    
-    kust = kus.patchTemplates("minio", ["00-minio-pvc.yaml","01-minio-dep.yaml","02-minio-svc.yaml"], data)    
+    data = util.get_minio_config_data()  
+
+    tplp = ["00-minio-pvc.yaml","01-minio-dep.yaml","02-minio-svc.yaml"]
+
+    if runtime == "openshift":
+        tplp.append("security-set-attach.yaml")
+
+    kust = kus.patchTemplates("minio", tplp, data)
     spec = kus.kustom_list("minio", kust, templates=[], data=data)
 
     if owner:

--- a/nuvolaris/redis.py
+++ b/nuvolaris/redis.py
@@ -54,8 +54,16 @@ def _add_redis_user_metadata(ucfg: UserConfig, user_metadata:UserMetadata):
 
 def create(owner=None):
     logging.info("create redis")
+    runtime = cfg.get('nuvolaris.kube')
     data = util.get_redis_config_data()
-    kust = kus.patchTemplate("redis", "set-attach.yaml", data)
+    
+    tplp = ["set-attach.yaml"]
+
+    if runtime == "openshift":
+        tplp.append("security-set-attach.yaml")
+
+    kust = kus.patchTemplates("redis",tplp , data)
+    
     spec = kus.kustom_list("redis", kust, templates=["redis-conf.yaml"], data=data)
 
     if owner:

--- a/nuvolaris/templates/01-minio-dep.yaml
+++ b/nuvolaris/templates/01-minio-dep.yaml
@@ -38,7 +38,7 @@ spec:
           claimName: minio-pv-claim
       containers:
       - name: minio
-        image: quay.io/minio/minio:RELEASE.2023-03-24T21-41-23Z
+        image: bitnami/minio:2023.3.24  
         command:
         - /bin/bash
         - -c
@@ -52,7 +52,6 @@ spec:
         ports:
         - containerPort: 9000
           hostPort: 9000
-        ports:
         - containerPort: 9090
           hostPort: 9090          
         volumeMounts:

--- a/nuvolaris/templates/ferretdb-sts.yaml
+++ b/nuvolaris/templates/ferretdb-sts.yaml
@@ -37,7 +37,7 @@ spec:
         name: nuvolaris-mongodb         
     spec:
       containers:
-      - image: ghcr.io/ferretdb/ferretdb:1.6.0
+      - image: ghcr.io/nuvolaris/ferretdb:1.6.0
         name: ferretdb
         env:
         - name: FERRETDB_POSTGRESQL_URL

--- a/nuvolaris/templates/security-dep-attach.yaml
+++ b/nuvolaris/templates/security-dep-attach.yaml
@@ -16,7 +16,7 @@
 # under the License.
 #
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{name}}
   namespace: nuvolaris
@@ -24,20 +24,13 @@ spec:
   template:
     spec:
       containers:
-        - name: {{container}}
-          volumeMounts:
-            - name: {{name}}-pvc
-              mountPath: {{dir}}
-  volumeClaimTemplates:
-  - metadata:
-      name: {{name}}-pvc
-    spec:
-      accessModes:
-        - 'ReadWriteOnce'
-      resources:
-        requests:
-          storage: {{size}}Gi
-      storageClassName: {{storageClass}}
-{% if hostpath %}
-      volumeName: {{name}}-pv
-{% endif %}
+      - name: {{container}}
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          runAsNonRoot: true

--- a/nuvolaris/templates/security-set-attach.yaml
+++ b/nuvolaris/templates/security-set-attach.yaml
@@ -24,20 +24,13 @@ spec:
   template:
     spec:
       containers:
-        - name: {{container}}
-          volumeMounts:
-            - name: {{name}}-pvc
-              mountPath: {{dir}}
-  volumeClaimTemplates:
-  - metadata:
-      name: {{name}}-pvc
-    spec:
-      accessModes:
-        - 'ReadWriteOnce'
-      resources:
-        requests:
-          storage: {{size}}Gi
-      storageClassName: {{storageClass}}
-{% if hostpath %}
-      volumeName: {{name}}-pv
-{% endif %}
+      - name: {{container}}
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          runAsNonRoot: true

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -313,6 +313,7 @@ def get_redis_config_data():
 
     data = {
         "name": "redis",
+        "container": "redis",
         "dir": "/redis-master-data",
         "size": cfg.get("redis.volume-size", "REDIS_VOLUME_SIZE", 10),
         "storageClass": cfg.get("nuvolaris.storageclass"),
@@ -333,6 +334,8 @@ def get_service(jsonpath,namespace="nuvolaris"):
 # return minio configuration parameters with default values if not configured
 def get_minio_config_data():
     data = {
+        "name":"minio-deployment",
+        "container":"minio",
         "minio_host": cfg.get('minio.host') or "minio",
         "minio_volume_size": cfg.get('minio.volume-size') or "5",
         "minio_root_user": cfg.get('minio.admin.user') or "minio",

--- a/tests/volume_test.ipy
+++ b/tests/volume_test.ipy
@@ -35,6 +35,7 @@ assert(not kube.get("po/test-nginx-0"))
 assert(len(kube.get("pvc")["items"]) ==0)
 
 data = {"name": "test-nginx", 
+        "container": "test-nginx",
         "size": "1", 
         "dir": "/usr/share/nginx/html",
         "storageClass": cfg.get("nuvolaris.storageclass")


### PR DESCRIPTION
This PR uses non root based images for MINIO, REDIS and FERRETDB. In addition when deploying on Openshift deploys the corresponding PODs with a specific securityContext

```
        securityContext:
          capabilities:
            drop:
              - ALL
          seccompProfile:
            type: RuntimeDefault
          allowPrivilegeEscalation: false
          readOnlyRootFilesystem: false
          runAsNonRoot: true
```