### PR TITLE
chore: various fix to deploy the operator on openshift

### DIFF
--- a/deploy/minio/01-minio-dep.yaml
+++ b/deploy/minio/01-minio-dep.yaml
@@ -53,10 +53,10 @@ spec:
         - name: MINIO_ROOT_PASSWORD
           value: minio123
         ports:
-        - containerPort: 9000
-          hostPort: 9000
-        - containerPort: 9090
-          hostPort: 9090          
+        - name: api
+          containerPort: 9000
+        - name: content
+          containerPort: 9090        
         volumeMounts:
         - name: storage # must match the volume name, above
           mountPath: "/storage"

--- a/deploy/nginx-static/nginx-static-sts.yaml
+++ b/deploy/nginx-static/nginx-static-sts.yaml
@@ -39,7 +39,7 @@ spec:
         command: ['sh', '-c', "until nslookup minio.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for minio; sleep 2; done"]     
       containers:
       - name: nuvolaris-static
-        image: nginx
+        image: bitnami/nginx:1.25.1
         ports:
         - containerPort: 80
         volumeMounts:

--- a/deploy/nuvolaris-permissions/kubegres-crd.yaml
+++ b/deploy/nuvolaris-permissions/kubegres-crd.yaml
@@ -21,7 +21,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
   name: kubegres.kubegres.reactive-tech.io
 spec:
   group: kubegres.reactive-tech.io

--- a/deploy/nuvolaris-permissions/nuvolaris-kubegres-roles.yaml
+++ b/deploy/nuvolaris-permissions/nuvolaris-kubegres-roles.yaml
@@ -149,27 +149,19 @@ rules:
   resources:
   - kubegres
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - "*"
 - apiGroups:
   - kubegres.reactive-tech.io
   resources:
   - kubegres/finalizers
   verbs:
-  - update
+  - "*"
 - apiGroups:
   - kubegres.reactive-tech.io
   resources:
   - kubegres/status
   verbs:
-  - get
-  - patch
-  - update
+  - "*"
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/deploy/nuvolaris-permissions/operator-roles.yaml
+++ b/deploy/nuvolaris-permissions/operator-roles.yaml
@@ -82,9 +82,9 @@ rules:
   resources: ["middlewares"]
   verbs: ["get","patch","list","update","watch","create","delete"]
 
-# required for kubegres
-- apiGroups: ["kubegres.reactive-tech.io"]
-  resources: ["kubegres","kubegres/finalizers","kubegres/status"]
+# required for kubegres #resources: 
+- apiGroups: ["kubegres.reactive-tech.io"]  
+  resources: ["kubegres","kubegres/status","kubegres/finalizers"]
   verbs: ["get","patch","list","update","watch","create","delete"]
 
 ---

--- a/nuvolaris/minio.py
+++ b/nuvolaris/minio.py
@@ -65,7 +65,7 @@ def create(owner=None):
     tplp = ["00-minio-pvc.yaml","01-minio-dep.yaml","02-minio-svc.yaml"]
 
     if runtime == "openshift":
-        tplp.append("security-set-attach.yaml")
+        tplp.append("security-dep-attach.yaml")
 
     kust = kus.patchTemplates("minio", tplp, data)
     spec = kus.kustom_list("minio", kust, templates=[], data=data)

--- a/nuvolaris/templates/01-minio-dep.yaml
+++ b/nuvolaris/templates/01-minio-dep.yaml
@@ -50,10 +50,10 @@ spec:
         - name: MINIO_ROOT_PASSWORD
           value: {{minio_root_password}}
         ports:
-        - containerPort: 9000
-          hostPort: 9000
-        - containerPort: 9090
-          hostPort: 9090          
+        - name: api
+          containerPort: 9000
+        - name: content
+          containerPort: 9090         
         volumeMounts:
         - name: storage # must match the volume name, above
           mountPath: "/storage"

--- a/nuvolaris/templates/nginx-static-sts.yaml
+++ b/nuvolaris/templates/nginx-static-sts.yaml
@@ -39,7 +39,7 @@ spec:
         command: ['sh', '-c', "until nslookup {{minio_host}}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for minio; sleep 2; done"]     
       containers:
       - name: nuvolaris-static
-        image: nginx
+        image: bitnami/nginx:1.25.1
         ports:
         - containerPort: 80
         volumeMounts:

--- a/tests/openshift/whisk.yaml
+++ b/tests/openshift/whisk.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: nuvolaris
 spec:
   nuvolaris:
-    apihost: $APIHOST_OSH
+    apihost: api.apps.nuvolaris.osh.n9s.cc #$APIHOST_OSH
   components:
     # start openwhisk controller
     openwhisk: true
@@ -39,7 +39,7 @@ spec:
     # start cron based action parser
     cron: true 
     # tls enabled or not
-    tls: true
+    tls: false
     # minio enabled or not
     minio: true 
     # minio static enabled or not


### PR DESCRIPTION
This PR provides various fixes to properly deploy nuvolaris operator to open shift

- use bitnami:nginx for the minio static provider
- fix a bug preventing MINIO deployment on open shift
- moves kubegres.crd under nuvolaris-permission to be applied before operator deployment as it may fail for some open shift specific setup