### PR TITLE
Implements nuvolaris/nuvolaris#248

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,7 +86,7 @@ tasks:
       
   env: env
   
-  watch: watch kubectl -n {{.NS}} get nodes,pod,svc,pvc,ingress
+  watch: watch kubectl -n {{.NS}} get nodes,pod,svc,pvc,ingress,route
   watch-osh: watch kubectl -n {{.NS}} get nodes,pod,svc,pvc
   watch-cert: watch kubectl -n {{.NS}} get ingress,ClusterIssuers,Certificates,CertificateRequests,Orders,Challenges 
   watch-pod: watch kubectl -n {{.NS}} get po,job --no-headers

--- a/deploy/acme-openshift/acme-rbac.yaml
+++ b/deploy/acme-openshift/acme-rbac.yaml
@@ -1,0 +1,114 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: openshift-acme
+  namespace: default
+  labels:
+    app: openshift-acme
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-acme
+  labels:
+    app: openshift-acme
+rules:
+- apiGroups:
+  - "route.openshift.io"
+  resources:
+  - routes
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - deletecollection
+
+- apiGroups:
+  - "route.openshift.io"
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+
+- apiGroups:
+  - ""
+  resources:
+  - limitranges
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - "apps"
+  resources:
+  - replicasets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-acme-crb
+  namespace: default
+  labels:
+    app: openshift-acme-crb
+subjects:
+- kind: ServiceAccount
+  name:  openshift-acme
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: openshift-acme
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/acme-openshift/acme-setup.yaml
+++ b/deploy/acme-openshift/acme-setup.yaml
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: letsencrypt-live
+  namespace: default
+  annotations:
+    "acme.openshift.io/priority": "100"
+  labels:
+    managed-by: "openshift-acme"
+    type: "CertIssuer"
+data:
+  "cert-issuer.types.acme.openshift.io": '{"type":"ACME","acmeCertIssuer":{"directoryUrl":"https://acme-v02.api.letsencrypt.org/directory"}}'
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: openshift-acme
+  namespace: default
+  labels:
+    app: openshift-acme
+  annotations:
+spec:
+  selector:
+    matchLabels:
+      app: openshift-acme
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: openshift-acme
+    spec:
+      serviceAccountName: openshift-acme
+      containers:
+      - name: openshift-acme
+        image: quay.io/tnozicka/openshift-acme:controller
+        imagePullPolicy: Always
+        args:
+        - --exposer-image=quay.io/tnozicka/openshift-acme:exposer
+        - --loglevel=4

--- a/nuvolaris/issuer.py
+++ b/nuvolaris/issuer.py
@@ -44,7 +44,8 @@ def create(owner=None):
         "acme_registered_email": acme_registered_email,
         "acme_server_url": acme_server_url,
         "issuer_class":issuer_class,
-        "name": "tls"
+        "name": "tls",
+        "runtime": runtime
     }
     
     kust = kus.patchTemplate("issuer", "cluster-issuer.yaml", data)

--- a/nuvolaris/main.py
+++ b/nuvolaris/main.py
@@ -99,7 +99,7 @@ def whisk_create(spec, name, **kwargs):
     else:
         state['redis'] = "off"
 
-    if cfg.get('components.tls') and not runtime in [ "kind", "openshift"]:
+    if cfg.get('components.tls') and not runtime in ["kind","openshift"]:
         try:
             msg = issuer.create(owner)
             state['issuer'] = "on"

--- a/nuvolaris/templates/cluster-issuer.yaml
+++ b/nuvolaris/templates/cluster-issuer.yaml
@@ -31,6 +31,10 @@ spec:
       name: nuvolaris-letsencrypt-secret
     # Enable the HTTP-01 challenge provider
     solvers:
-    - http01:
+    - http01:        
+        {% if runtime != 'openwhisk' %}
         ingress:
           class: {{issuer_class}}
+        {% else %}
+        ingress: {}
+        {% endif %}

--- a/nuvolaris/templates/generic-openshift-route-tpl.yaml
+++ b/nuvolaris/templates/generic-openshift-route-tpl.yaml
@@ -24,9 +24,12 @@ metadata:
     app: {{route_name}}
   annotations:
     haproxy.router.openshift.io/timeout: {{route_timeout_seconds}}s   
-  {% if is_static_ingress and apply_route_rewrite_rule %}
+    {% if tls %}
+    kubernetes.io/tls-acme: "true"
+    {% endif %}    
+    {% if is_static_ingress and apply_route_rewrite_rule %}
     haproxy.router.openshift.io/rewrite-target: {{rewrite_target}}/      
-  {% endif %}  
+    {% endif %}  
 spec:
   host: {{hostname}}
   to:
@@ -36,5 +39,5 @@ spec:
     targetPort: {{service_port}}
 {% if tls %}
   tls:
-    termination: edge
+    termination: edge    
 {% endif %}

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -46,6 +46,7 @@ def nuv_retry(deadline_seconds=120, max_backoff=5):
                     if current_t + backoff_delay < deadline:
                         time.sleep(backoff_delay)
                         retry_number += 1
+                        logging.warn(f"#{retry_number} nuv_retry detected a failure...")
                         continue  # retry again
                     else:
                         raise

--- a/nuvolaris/whisk_system_util.py
+++ b/nuvolaris/whisk_system_util.py
@@ -24,6 +24,8 @@ import nuvolaris.template as ntp
 import nuvolaris.util as util
 import os
 
+from nuvolaris.util import nuv_retry
+
 class WhiskSystemClient:
     def __init__(self, auth):
         self.controller_host   = cfg.get("controller.host","CONTROLLER_HOST","controller")
@@ -34,6 +36,7 @@ class WhiskSystemClient:
         logging.info(f"Created a WhiskSystemClient instance pointing to {self.ow_host_url}")
 
     # wraps a wsk --apihost <> -u <auth> *kwargs
+    @nuv_retry()
     def wsk(self, *kwargs):        
         cmd = ["wsk","--apihost",self.ow_host_url,"--auth",self.admin_auth]
         cmd += list(kwargs)
@@ -55,4 +58,4 @@ class WhiskSystemClient:
             return returncode == 0
         except Exception as e:
             logging.error(e)
-            return e           
+            raise e

--- a/tests/openshift/whisk.yaml
+++ b/tests/openshift/whisk.yaml
@@ -39,7 +39,7 @@ spec:
     # start cron based action parser
     cron: true 
     # tls enabled or not
-    tls: false
+    tls: true
     # minio enabled or not
     minio: true 
     # minio static enabled or not


### PR DESCRIPTION
This PR provides the following improvements

- add retries attempt to whisk_system action deployment to ensure system actions (login currently) are properly deployed
- add support for acme-open shift helper when configuring a route over open shift with enabled TLS