### PR TITLE
Fixes nuvolaris/nuvolaris#249

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,8 +86,8 @@ tasks:
       
   env: env
   
-  watch: watch kubectl -n {{.NS}} get nodes,pod,svc,pvc,ingress,route
-  watch-osh: watch kubectl -n {{.NS}} get nodes,pod,svc,pvc
+  watch: watch kubectl -n {{.NS}} get nodes,pod,svc,pvc,ingress
+  watch-osh: watch kubectl -n {{.NS}} get nodes,pod,svc,pvc,route
   watch-cert: watch kubectl -n {{.NS}} get ingress,ClusterIssuers,Certificates,CertificateRequests,Orders,Challenges 
   watch-pod: watch kubectl -n {{.NS}} get po,job --no-headers
 

--- a/deploy/nginx-static/nginx-static-cm.yaml
+++ b/deploy/nginx-static/nginx-static-cm.yaml
@@ -23,7 +23,7 @@ metadata:
 data:
   default.conf: |
     server {
-      listen       80;
+      listen       8080;
       server_name  localhost;
 
       #access_log  /var/log/nginx/host.access.log  main;
@@ -49,8 +49,8 @@ data:
           proxy_hide_header     x-amz-server-side-encryption;        
           proxy_set_header Host $http_host;
 
-          proxy_pass http://staticminio.minio.svc.cluster.local:9001/;
-        proxy_redirect     off;
+          proxy_pass http://minio.nuvolaris.svc.cluster.local:9000/;
+          proxy_redirect     off;
       }      
 
       #error_page  404              /404.html;
@@ -61,27 +61,37 @@ data:
       location = /50x.html {
           root   /usr/share/nginx/html;
       }
-
-      # proxy the PHP scripts to Apache listening on 127.0.0.1:80
-      #
-      #location ~ \.php$ {
-      #    proxy_pass   http://127.0.0.1;
-      #}
-
-      # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-      #
-      #location ~ \.php$ {
-      #    root           html;
-      #    fastcgi_pass   127.0.0.1:9000;
-      #    fastcgi_index  index.php;
-      #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
-      #    include        fastcgi_params;
-      #}
-
-      # deny access to .htaccess files, if Apache's document root
-      # concurs with nginx's one
-      #
-      #location ~ /\.ht {
-      #    deny  all;
-      #}
     }
+  
+  nginx.conf: |
+    user nginx;
+    worker_processes  auto;
+
+    error_log  /tmp/nginx/error.log notice;
+    pid        /tmp/nginx.pid;
+
+
+    events {
+        worker_connections  1024;
+    }
+
+
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+        access_log  /tmp/nginx/access.log  main;
+
+        sendfile        on;
+        #tcp_nopush     on;
+
+        keepalive_timeout  65;
+
+        #gzip  on;
+
+        include /etc/nginx/conf.d/*.conf;
+    }  

--- a/deploy/nginx-static/nginx-static-sts.yaml
+++ b/deploy/nginx-static/nginx-static-sts.yaml
@@ -39,18 +39,18 @@ spec:
         command: ['sh', '-c', "until nslookup minio.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for minio; sleep 2; done"]     
       containers:
       - name: nuvolaris-static
-        image: bitnami/nginx:1.25.1
+        image: nginxinc/nginx-unprivileged
         ports:
-        - containerPort: 80
+        - containerPort: 8080
         volumeMounts:
           - name: nginx-default-conf
             mountPath: /etc/nginx/conf.d/default.conf
             subPath: default.conf
-            readOnly: false
+            readOnly: false          
       volumes:
         - name: nginx-default-conf
           configMap:
             name: nginx-static-conf-cm
             items:
               - key: default.conf
-                path: default.conf            
+                path: default.conf                           

--- a/nuvolaris/postgres_operator.py
+++ b/nuvolaris/postgres_operator.py
@@ -155,9 +155,9 @@ def render_postgres_script(namespace,template,data):
 def exec_psql_command(pod_name,path_to_psql_script,path_to_pgpass):
     logging.info(f"passing script {path_to_psql_script} to pod {pod_name}")
     res = kube.kubectl("cp",path_to_psql_script,f"{pod_name}:{path_to_psql_script}")
-    res = kube.kubectl("cp",path_to_pgpass,f"{pod_name}:/root/.pgpass")
-    res = kube.kubectl("exec","-it",pod_name,"--","/bin/bash","-c",f"chmod 600 /root/.pgpass")
-    res = kube.kubectl("exec","-it",pod_name,"--","/bin/bash","-c",f"psql --username postgres --dbname postgres -f {path_to_psql_script}")
+    res = kube.kubectl("cp",path_to_pgpass,f"{pod_name}:/tmp/.pgpass")
+    res = kube.kubectl("exec","-it",pod_name,"--","/bin/bash","-c",f"chmod 600 /tmp/.pgpass")
+    res = kube.kubectl("exec","-it",pod_name,"--","/bin/bash","-c",f"PGPASSFILE='/tmp/.pgpass' psql --username postgres --dbname postgres -f {path_to_psql_script}")
     os.remove(path_to_psql_script)
     os.remove(path_to_pgpass)
     return res

--- a/nuvolaris/templates/generic-openshift-route-tpl.yaml
+++ b/nuvolaris/templates/generic-openshift-route-tpl.yaml
@@ -25,10 +25,11 @@ metadata:
   annotations:
     haproxy.router.openshift.io/timeout: {{route_timeout_seconds}}s   
     {% if tls %}
-    kubernetes.io/tls-acme: "true"
+    kubernetes.io/tls-acme: "true"   
     {% endif %}    
     {% if is_static_ingress and apply_route_rewrite_rule %}
-    haproxy.router.openshift.io/rewrite-target: {{rewrite_target}}/      
+    haproxy.router.openshift.io/rewrite-target: {{rewrite_target}}/
+    http.exposer.acme.openshift.io/filter-out-annotations: "rewrite-target"    
     {% endif %}  
 spec:
   host: {{hostname}}

--- a/nuvolaris/templates/nginx-static-cm.yaml
+++ b/nuvolaris/templates/nginx-static-cm.yaml
@@ -23,7 +23,7 @@ metadata:
 data:
   default.conf: |
     server {
-      listen       80;
+      listen       8080;
       server_name  localhost;
 
       #access_log  /var/log/nginx/host.access.log  main;
@@ -49,8 +49,8 @@ data:
           proxy_hide_header     x-amz-server-side-encryption;        
           proxy_set_header Host $http_host;
 
-          proxy_pass http://{{minio_host}}.nuvolaris.svc.cluster.local:{{minio_post}}/;
-        proxy_redirect     off;
+          proxy_pass http://{{minio_host}}.nuvolaris.svc.cluster.local:{{minio_port}}/;
+          proxy_redirect     off;
       }      
 
       #error_page  404              /404.html;
@@ -62,26 +62,37 @@ data:
           root   /usr/share/nginx/html;
       }
 
-      # proxy the PHP scripts to Apache listening on 127.0.0.1:80
-      #
-      #location ~ \.php$ {
-      #    proxy_pass   http://127.0.0.1;
-      #}
+    }
+  
+  nginx.conf: |
+    user nginx;
+    worker_processes  auto;
 
-      # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-      #
-      #location ~ \.php$ {
-      #    root           html;
-      #    fastcgi_pass   127.0.0.1:9000;
-      #    fastcgi_index  index.php;
-      #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
-      #    include        fastcgi_params;
-      #}
+    error_log  /tmp/nginx/error.log notice;
+    pid        /tmp/nginx.pid;
 
-      # deny access to .htaccess files, if Apache's document root
-      # concurs with nginx's one
-      #
-      #location ~ /\.ht {
-      #    deny  all;
-      #}
-    }    
+
+    events {
+        worker_connections  1024;
+    }
+
+
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+        access_log  /tmp/nginx/access.log  main;
+
+        sendfile        on;
+        #tcp_nopush     on;
+
+        keepalive_timeout  65;
+
+        #gzip  on;
+
+        include /etc/nginx/conf.d/*.conf;
+    }        

--- a/nuvolaris/templates/nginx-static-sts.yaml
+++ b/nuvolaris/templates/nginx-static-sts.yaml
@@ -39,18 +39,18 @@ spec:
         command: ['sh', '-c', "until nslookup {{minio_host}}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for minio; sleep 2; done"]     
       containers:
       - name: nuvolaris-static
-        image: bitnami/nginx:1.25.1
+        image: nginxinc/nginx-unprivileged
         ports:
-        - containerPort: 80
+        - containerPort: 8080
         volumeMounts:
           - name: nginx-default-conf
             mountPath: /etc/nginx/conf.d/default.conf
             subPath: default.conf
-            readOnly: true
+            readOnly: false           
       volumes:
         - name: nginx-default-conf
           configMap:
             name: nginx-static-conf-cm
             items:
               - key: default.conf
-                path: default.conf            
+                path: default.conf                

--- a/tests/openshift/whisk-user.yaml
+++ b/tests/openshift/whisk-user.yaml
@@ -14,20 +14,34 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-apiVersion: v1
-kind: Service
+#
+apiVersion: nuvolaris.org/v1
+kind: WhiskUser
 metadata:
-  name: nuvolaris-static-svc
-  labels:
-    app: nuvolaris-static
-spec:
-  type: ClusterIP
-  ports:
-  - name: http
-    port: 8080
-    protocol: TCP
-    targetPort: 8080
-  selector:
-    app: nuvolaris-static
-  sessionAffinity: None
+  name: franztt
+  namespace: nuvolaris
+spec: 
+  email: francesco@nuvolaris.io
+  password: apassw0rd
+  namespace: franztt
+  auth: 51b64cd0-d765-419e-990d-d7dd30d7b68f:vPtIjR2MFMlYY7U5BY6N7TTogZXnJa8cl6ygPGnJIXOJonfA6MuNpVAdLN7m8iVc
+  redis:
+    enabled: true
+    prefix: franztt
+    password: fttredispwd
+  object-storage:        
+    password: vPtIjR2MFMlYY7U5BY6N7TTogZXnJa8cl6ygPGnJIXOJonfA6MuNpVAdLN7m8iVc
+    data:
+      enabled: true
+      bucket: franztt-data
+    route:
+      enabled: true
+      bucket: franztt-web
+  mongodb:
+    enabled: true
+    database: franztt
+    password: ahfdajsfdafdasffdasdja
+  postgres:
+    enabled: true
+    database: franztt
+    password: urghgdghhggkjdgksdjh     

--- a/tests/openshift/whisk.yaml
+++ b/tests/openshift/whisk.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: nuvolaris
 spec:
   nuvolaris:
-    apihost: api.apps.nuvolaris.osh.n9s.cc #$APIHOST_OSH
+    apihost: fttapi.apps.nuvolaris.osh.n9s.cc #$APIHOST_OSH
   components:
     # start openwhisk controller
     openwhisk: true


### PR DESCRIPTION
This PR fixes and provides improvements to

- fix an issue with postgres deployer when executing the script to create/drop user database by creating a /tmp/.pgpass file and passing reference with an env variable
- uses niginx-unprivileged image to be compliant with open shift requirements
- creates routes for static content adding an annotation to exclude the haproxy.router.openshift.io/rewrite-target ones which was giving problem in the route created buy the openshift-acme controller for the http-01 challenge