### PR TITLE
chore:  checks for couchdb pod readiness before OpenWhisk controller deployment

### DIFF
--- a/nuvolaris/openwhisk.py
+++ b/nuvolaris/openwhisk.py
@@ -19,11 +19,15 @@ import logging
 import nuvolaris.config as cfg
 import nuvolaris.openwhisk_standalone as standalone
 import nuvolaris.kube as kube
+import nuvolaris.util as util
 
 def annotate(keyval):
     kube.kubectl("annotate", "cm/config",  keyval, "--overwrite")
 
 def create(owner=None):
+    # openwhisk controller relies on couchdb therefore we wait for pod readiness
+    util.wait_for_pod_ready("{.items[?(@.metadata.labels.name == 'couchdb')].metadata.name}")
+
     useInvoker = cfg.get('components.invoker') or False
     
     if not useInvoker:


### PR DESCRIPTION
Using nuvolaris-testing suite on off the shelf created kubernetes cluster on not so powerfull servers it has been noted that attempt to use OpenWhisk API fails due to some un-expected authentication issue. These are due to the fact that couchdb pod deployment may take some time and therefore openwhisk controller pad could reach readiness status even before the couchdb one. Under such cicurmstances openmwhisk couchdb metadata are not yet loaded and therefore any attempt to use openwhisk miserably fail.

This PR introduces a precheck condition on OpenWhisk standalone controller deployment based on couchdb pod readiness. 