### PR TITLE
fix: non root pods needs pod security policy on both gke and eks clus…

### DIFF
--- a/detect.sh
+++ b/detect.sh
@@ -34,6 +34,8 @@ elif echo "$LABELS" | jq . | grep microk8s.io >/dev/null
 then echo "microk8s"
 elif echo "$LABELS" | jq . | grep lke.linode.com >/dev/null
 then echo "lks"
+elif echo "$LABELS" | jq . | grep cloud.google.com/gke >/dev/null
+then echo "gke"
 elif echo "$LABELS" | jq . | grep openshift.io >/dev/null
 then echo "openshift"
 elif echo "$LABELS" | jq . | grep 'instance-type.*k3s' >/dev/null

--- a/nuvolaris/config.py
+++ b/nuvolaris/config.py
@@ -118,6 +118,9 @@ def detect_labels(labels=None):
             elif j.endswith("kubernetes.io/instance-type") and i[j] == "k3s":
                 kube = "k3s"
                 break
+            elif j.find("cloud.google.com/gke") >=0:
+                kube = "gke"
+                break            
             # assign all the 'nuvolaris.io' labels
         
     if kube:

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -395,4 +395,4 @@ def get_enable_pod_security():
     for some specific pod. This is currently used for EKS bitnami based images.
     """
     runtime = cfg.get('nuvolaris.kube')
-    return runtime in ["eks"]
+    return runtime in ["eks","gke","aks","generic"]


### PR DESCRIPTION
This PR provides following improvements

- capability to detect when running on a GKE cluster
- enables pod security level on EKS, GKE, AKS and generic cluster for non root based images.