### PR TITLE
Aks fix

### DIFF
--- a/deploy/nginx-static/nginx-static-sts.yaml
+++ b/deploy/nginx-static/nginx-static-sts.yaml
@@ -39,7 +39,7 @@ spec:
         command: ['sh', '-c', "until nslookup minio.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for minio; sleep 2; done"]     
       containers:
       - name: nuvolaris-static
-        image: nginxinc/nginx-unprivileged
+        image: nginxinc/nginx-unprivileged:1.24
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/nuvolaris/couchdb.py
+++ b/nuvolaris/couchdb.py
@@ -78,6 +78,11 @@ def create(owner=None):
     else:
         cfg.put("state.couchdb.spec", spec)
     res = kube.apply(spec)
+
+    if res:
+        # dynamically detect couchdb pod and wait for readiness
+        util.wait_for_pod_ready("{.items[?(@.metadata.labels.name == 'couchdb')].metadata.name}")
+
     return res
 
 def delete():

--- a/nuvolaris/main.py
+++ b/nuvolaris/main.py
@@ -35,6 +35,10 @@ import nuvolaris.whisk_actions_deployer as system
 import nuvolaris.version_util as version_util
 import nuvolaris.postgres_operator as postgres
 
+@kopf.on.startup()
+def configure(settings: kopf.OperatorSettings, **_):
+  settings.watching.server_timeout = 210
+
 # tested by an integration test
 @kopf.on.login()
 def login(**kwargs):
@@ -298,4 +302,4 @@ def runtimes_cm_event_watcher(event, **kwargs):
     owner = kube.get(f"wsk/controller")
 
     if cfg.get('components.openwhisk'):
-        patcher.restart_whisk(owner)
+        patcher.restart_whisk(owner)     

--- a/nuvolaris/templates/nginx-static-sts.yaml
+++ b/nuvolaris/templates/nginx-static-sts.yaml
@@ -39,7 +39,7 @@ spec:
         command: ['sh', '-c', "until nslookup {{minio_host}}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for minio; sleep 2; done"]     
       containers:
       - name: nuvolaris-static
-        image: nginxinc/nginx-unprivileged
+        image: nginxinc/nginx-unprivileged:1.24
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/tests/aks/whisk.yaml
+++ b/tests/aks/whisk.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: nuvolaris
 spec:
   nuvolaris:
-      apihost: provaaks.prova.n9s.cc
+      apihost: auto
   components:
     # start openwhisk controller
     openwhisk: true
@@ -39,7 +39,7 @@ spec:
     # start cron based action parser
     cron: true
     # tls enabled or not
-    tls: true
+    tls: false
     # minio enabled or not
     minio: true
     # minio static enabled or not


### PR DESCRIPTION
This PR contributes various fixes coming from AKS testing
- adds settings.watching.server_timeout = 210 to kopf startup to solve operator stopping receiving events when running on AKS
- fix a bug which was configuring static content provider with basic path to user bucket even when it was not required.
- bump nginx static content provider image to nginxinc/nginx-unprivileged:1.24