### PR TITLE
Implements nuvolaris/nuvolaris#262

### DIFF
--- a/actions/Taskfile.yml
+++ b/actions/Taskfile.yml
@@ -34,6 +34,8 @@ vars:
     sh: yq .spec.couchdb.admin.password {{.CONFIG}}
   CDB_HOST:
     sh: yq .spec.couchdb.host {{.CONFIG}}
+  MINIO_HOST: minio.nuvolaris.svc.cluster.local   
+  MINIO_PORT: 9000    
 
 tasks:
 
@@ -72,6 +74,23 @@ tasks:
     - > 
       {{.WSKSYS}} action get nuv/login --url
 
+  upload:prepare:
+    - |-
+      cd upload
+      rm  -f ../{{.DEPLOY}}/upload.zip
+      zip -r ../{{.DEPLOY}}/upload.zip *
+
+  upload:deploy:
+    - > 
+      {{.WSKSYS}} package update nuv
+      -p minio_host {{.MINIO_HOST}}
+      -p minio_port {{.MINIO_PORT}}  
+    - > 
+      {{.WSKSYS}} action update nuv/upload 
+      {{.DEPLOY}}/upload.zip --kind python:3 --web true
+    - > 
+      {{.WSKSYS}} action get nuv/upload --url             
+
   login:webtest:
     - >
       curl -X POST {{.APIHOST}}/api/v1/web/whisk-system/nuv/login -H "Content-Type: application/json" -d '{"login": "{{.USERNAME}}", "password": "{{.PASSWORD}}"}'
@@ -82,14 +101,36 @@ tasks:
 
   login:k3sproxy:
     - >
-      curl -X POST https://gptuser.api.k3s.nuvtest.net/api/v1/web/whisk-system/nuv/login -H "Content-Type: application/json" -d '{"login": "{{.USERNAME}}", "password": "{{.PASSWORD}}"}'      
+      curl -X POST https://gptuser.api.k3s.nuvtest.net/api/v1/web/whisk-system/nuv/login -H "Content-Type: application/json" -d '{"login": "{{.USERNAME}}", "password": "{{.PASSWORD}}"}'
+
+  upload:webtest:
+    - >
+      curl -X PUT -T ../nuvolaris/templates/index.html -H "minioauth: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" {{.APIHOST}}/api/v1/web/whisk-system/nuv/upload/nuvolaris/index2.html
+
+  upload:webtest2:
+    - >
+      curl -X PUT -T ../nuvolaris/templates/index.html -H "minioauth: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" {{.APIHOST}}/api/v1/web/whisk-system/nuv/upload/nuvolaris/.well-known/index2.html
+
 
   login:all:
     - task: login:prepare
     - task: login:deploy
     - task: login:webtest
 
+  upload:all:
+    - task: upload:prepare
+    - task: upload:deploy   
+
   # prepares all the system related actions
   prepare:
     - task: login:prepare
+    - task: upload:prepare
+
+  deploy:
+    - task: login:deploy
+    - task: upload:deploy
+
+  all:
+    - task: prepare
+    - task: deploy        
                     

--- a/actions/system.yml
+++ b/actions/system.yml
@@ -17,6 +17,9 @@
 #
 version: '3'
 
+vars:
+  DEPLOY: "../deploy/whisk-system"
+  
 tasks:
 
   login:prepare:
@@ -28,7 +31,14 @@ tasks:
       rm  -f ../{{.DEPLOY}}/login.zip
       zip -r ../{{.DEPLOY}}/login.zip *
 
+  upload:prepare:
+    - |-
+      cd upload
+      rm  -f ../{{.DEPLOY}}/upload.zip
+      zip -r ../{{.DEPLOY}}/upload.zip *      
+
   # prepares all the system related actions
   prepare:
     - task: login:prepare   
+    - task: upload:prepare
                     

--- a/actions/upload/__main__.py
+++ b/actions/upload/__main__.py
@@ -1,0 +1,160 @@
+import logging, json
+import os
+import base64
+import random
+import string
+
+from minio import Minio
+from minio.error import S3Error
+
+def build_error(message: str):
+    return {
+        "statusCode": 400,
+        "body": message
+    }
+
+def build_response(user, filename,bucket, upload_result):
+    body = {
+        "user":user,
+        "filename":filename,
+        "bucket":bucket,
+        "uploaded": upload_result
+    }
+
+    return {
+        "statusCode": upload_result and 200 or 400,
+        "body": body
+    }
+
+def build_mo_client(host, port, access_key, secret_key):
+    """
+    Creates an Minio client pointing to the given MINIO HOST
+    :param host, minio host
+    :param port, minio api port normally it is the 9000
+    :param access_key user we are representing
+    :param secret_key to access minio
+    """
+    mo_client = Minio(f"{host}:{port}",access_key=access_key,secret_key=secret_key,secure=False)    
+    return mo_client
+            
+def upload_file(mo_client, file, bucket, object_name=None):
+    """Upload a file to an S3 bucket
+
+    :param file_name: File to upload
+    :param bucket: Bucket to upload to
+    :param object_name: S3 object name. If not specified then file_name is used
+    :return: True if file was uploaded, else False
+    """
+
+    # If S3 object_name was not specified, use file_name
+    if object_name is None:
+        object_name = os.path.basename(file)
+
+    print(f"uploading {object_name} into bucket {bucket} from tmp_file {file}")    
+
+    # Upload the file
+    try:
+        response = mo_client.fput_object(bucket_name=bucket,object_name=object_name,file_path=file)
+        if response._object_name:
+            return True
+    except Exception as e:
+        logging.error(e)
+        return False
+    return False
+
+def process_path_param(ow_path: str):
+    """ Process the __ow_path parameters to extract username and fully qualified filename
+
+    :parma ow_path, the __ow_path parameter passed by openwhisk action controller
+    :return a dictionary {user:<user>, filename:<filepath>}
+    """
+    path_params = ow_path
+    if ow_path.startswith("/"):
+        path_params = ow_path[1:None]
+
+    path_elements = path_params.split("/")
+
+    upload_data = {}
+
+    if len(path_elements) >= 1:
+        upload_data['user']=path_elements[0]
+        upload_data['filename']=path_params.replace(f"{upload_data['user']}/","")
+
+    return upload_data
+
+def delete_files_in_directory_and_subdirectories(directory_path):
+   try:
+     for root, dirs, files in os.walk(directory_path):
+       for file in files:
+         file_path = os.path.join(root, file)
+         os.remove(file_path)
+     print("All files and subdirectories deleted successfully.")
+   except OSError:
+     print("Error occurred while deleting files and subdirectories.")    
+
+def prepare_file_upload(username, filename, file_content_as_b64):
+    """ Creates a tmp area for the given user where the uploaded file will be stored under a random generated name
+        the fully qualified filename is taken into account only on the corresponding destination bucket.
+    param: username
+    param: filename
+    param: file_content_as_b64
+    return: a file object pointing to the tmp file
+    """
+    try:
+        user_tmp_folder = f"/tmp/{username}"
+        if not os.path.exists(user_tmp_folder):
+            os.makedirs(user_tmp_folder)
+            print(f"added tmp folder {user_tmp_folder}")
+
+        delete_files_in_directory_and_subdirectories(user_tmp_folder)
+        tmp_file = f"{user_tmp_folder}/{random.choices(string.ascii_lowercase, k=10)}"
+        
+        with open(tmp_file, "wb") as f:
+            file_content=base64.b64decode(file_content_as_b64)          
+            f.write(file_content)
+
+        if os.path.exists(tmp_file):
+            print(f"{tmp_file} stored successfully.")
+            return tmp_file
+        else:
+            return None
+    except Exception as e:
+        print("error preparing tmp_files",e)
+        return None    
+
+def main(args):
+    """
+    Simple actions to upload a files into a minio bucket.
+    The upload action it is supposed to receive a path param similar
+    /<user>/<path>?<auth>
+    and will store the given path under the <user>-web bucket using mnio
+    """
+    print(args)
+
+    headers = args['__ow_headers']
+    if('minioauth' not in headers):
+        return build_error("invalid request, missing mandatory header: minioauth")
+    
+    if(len(args['__ow_body']) == 0):
+        return build_error("invalid request, no file content has been received")
+    
+    upload_data = process_path_param(args['__ow_path'])
+
+    if 'user' not in upload_data and 'filename' not in upload_data:
+        return build_error("invalid request, username and/or filename path error")
+    
+    minio_host = args['minio_host']
+    minio_port = args['minio_port']    
+    content_as_b64 = args['__ow_body']
+    auth = headers['minioauth']
+    
+    print(f"processing request to upload file {upload_data['filename']} under {upload_data['user']} web-bucket")
+
+    mo_client = build_mo_client(minio_host, minio_port,upload_data['user'], auth)
+    tmp_file = prepare_file_upload(upload_data['user'],upload_data['filename'],content_as_b64)
+
+    if tmp_file:
+        upload_result = upload_file(mo_client,tmp_file,f"{upload_data['user']}-web",upload_data['filename'])
+        return build_response(upload_data['user'],upload_data['filename'],f"{upload_data['user']}-web",upload_result)
+    else:
+        return build_error("Unexptected error upload action. Check activation log")

--- a/deploy/nuvolaris-permissions/openwhisk-runtimes-cm.yaml
+++ b/deploy/nuvolaris-permissions/openwhisk-runtimes-cm.yaml
@@ -87,7 +87,7 @@ data:
                     "image": {
                         "prefix": "ghcr.io/nuvolaris",
                         "name": "action-python-v311",
-                        "tag": "3.0.0-beta.2308150939"
+                        "tag": "3.0.0-beta.2309031758"
                     },
                     "deprecated": false,
                     "attached": {
@@ -114,7 +114,7 @@ data:
                     "image": {
                         "prefix": "ghcr.io/nuvolaris",
                         "name": "action-python-v310",
-                        "tag": "3.0.0-beta.2308150939"
+                        "tag": "3.0.0-beta.2309031758"
                     },
                     "deprecated": false,
                     "attached": {

--- a/nuvolaris/templates/generic-ingress-tpl.yaml
+++ b/nuvolaris/templates/generic-ingress-tpl.yaml
@@ -22,6 +22,7 @@ metadata:
   name: {{ingress_name}}
   namespace: nuvolaris
   annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: 0
       kubernetes.io/ingress.class: "{{ingress_class}}"
       {% if tls %}
       cert-manager.io/cluster-issuer: "letsencrypt-issuer"

--- a/nuvolaris/templates/whisk-system-manifest-tpl.yaml
+++ b/nuvolaris/templates/whisk-system-manifest-tpl.yaml
@@ -26,3 +26,7 @@ packages:
         function: login.zip
         runtime: python:3        
         web: true
+      upload:
+        function: upload.zip
+        runtime: python:3        
+        web: true        

--- a/nuvolaris/templates/whisk-system-manifest-tpl.yaml
+++ b/nuvolaris/templates/whisk-system-manifest-tpl.yaml
@@ -17,16 +17,15 @@
 #
 packages:
   nuv:
-    inputs:
-      {% for param in globals -%}
-        {{param.key}} : "{{param.value}}"
-      {% endfor %}
     actions:
-      login:
-        function: login.zip
-        runtime: python:3        
-        web: true
-      upload:
-        function: upload.zip
-        runtime: python:3        
-        web: true        
+      {% for action in actions -%}
+      # setting up {{action.name}} system action   
+      {{action.name}}:
+        function: {{action.function}}
+        runtime: {{action.runtime}}    
+        web: {{action.web}}        
+        inputs:
+          {% for param in action.inputs -%}
+          {{param.key}} : "{{param.value}}"
+          {% endfor %}
+      {% endfor %}     

--- a/nuvolaris/whisk_actions_deployer.py
+++ b/nuvolaris/whisk_actions_deployer.py
@@ -30,27 +30,53 @@ from nuvolaris.whisk_system_util import WhiskSystemClient
 from nuvolaris.util import nuv_retry
 from subprocess import CompletedProcess
 
-def prepare_system_actions_data():
-    data = {}
-    
+
+def prepare_login_action():
     couchdb_host = cfg.get("couchdb.host") or "couchdb"
     couchdb_port = cfg.get("couchdb.port") or "5984"
+
+    login_inputs=[]
+    login_inputs.append({"key":"couchdb_user", "value":cfg.get("couchdb.admin.user", "COUCHDB_ADMIN_USER", "whisk_admin")})
+    login_inputs.append({"key":"couchdb_password", "value":cfg.get("couchdb.admin.password", "COUCHDB_ADMIN_PASSWORD", "some_passw0rd")})
+    login_inputs.append({"key":"couchdb_host", "value":couchdb_host})
+
+    login = {
+        "name":"login",
+        "function":"login.zip",
+        "runtime":"python:3",
+        "web":"true",
+        "inputs":login_inputs
+    }
+
+    return login
+
+def prepare_upload_action():
     minio_host= cfg.get("minio.host") or "minio"
     minio_port= cfg.get("minio.port") or "9000"
     minio_full_host = f"{minio_host}.nuvolaris.svc.cluster.local"
 
-    globals=[]
-    globals.append({"key":"couchdb_user", "value":cfg.get("couchdb.admin.user", "COUCHDB_ADMIN_USER", "whisk_admin")})
-    globals.append({"key":"couchdb_password", "value":cfg.get("couchdb.admin.password", "COUCHDB_ADMIN_PASSWORD", "some_passw0rd")})
-    globals.append({"key":"couchdb_host", "value":couchdb_host})
-    globals.append({"key":"couchdb_port", "value":couchdb_port})
-    globals.append({"key":"minio_host", "value":minio_full_host})
-    globals.append({"key":"minio_port", "value":minio_port})
-    data = {
-        "globals":globals
+    upload_inputs=[]
+    upload_inputs.append({"key":"minio_host", "value":minio_full_host})
+    upload_inputs.append({"key":"minio_port", "value":minio_port})
+
+    upload = {
+        "name":"upload",
+        "function":"upload.zip",
+        "runtime":"python:3",
+        "web":"true",
+        "inputs":upload_inputs
     }
 
-    return data
+    return upload    
+
+
+def prepare_system_actions():
+    """ Builds a suitable structure to generate a deployment manifest using a template
+    """
+    actions = []
+    actions.append(prepare_login_action())
+    actions.append(prepare_upload_action())
+    return {"actions":actions}
 
 def process_wsk_result(result: CompletedProcess, expected_success_msg: str):
     """
@@ -93,7 +119,7 @@ def safe_deploy(wskClient):
 
 def deploy_whisk_system_action():
     auth = cfg.get('openwhisk.namespaces.whisk-system')
-    data = prepare_system_actions_data()
+    data = prepare_system_actions()
     tplres = kust.processTemplate("whisk-system","whisk-system-manifest-tpl.yaml",data,"manifest.yaml")
 
     wskClient = WhiskSystemClient(auth)

--- a/nuvolaris/whisk_actions_deployer.py
+++ b/nuvolaris/whisk_actions_deployer.py
@@ -35,12 +35,17 @@ def prepare_system_actions_data():
     
     couchdb_host = cfg.get("couchdb.host") or "couchdb"
     couchdb_port = cfg.get("couchdb.port") or "5984"
+    minio_host= cfg.get("minio.host") or "minio"
+    minio_port= cfg.get("minio.port") or "9000"
+    minio_full_host = f"{minio_host}.nuvolaris.svc.cluster.local"
 
     globals=[]
     globals.append({"key":"couchdb_user", "value":cfg.get("couchdb.admin.user", "COUCHDB_ADMIN_USER", "whisk_admin")})
     globals.append({"key":"couchdb_password", "value":cfg.get("couchdb.admin.password", "COUCHDB_ADMIN_PASSWORD", "some_passw0rd")})
     globals.append({"key":"couchdb_host", "value":couchdb_host})
     globals.append({"key":"couchdb_port", "value":couchdb_port})
+    globals.append({"key":"minio_host", "value":minio_full_host})
+    globals.append({"key":"minio_port", "value":minio_port})
     data = {
         "globals":globals
     }

--- a/whisk-system.sh
+++ b/whisk-system.sh
@@ -26,3 +26,6 @@ cp ${HOME}/nuvolaris/config.py ${HOME}/nuvolaris/couchdb_util.py ${HOME}/actions
 cd ${HOME}/actions/login
 rm  -f ${HOME}/deploy/whisk-system/login.zip
 zip -r ${HOME}/deploy/whisk-system/login.zip *
+cd ${HOME}/actions/upload
+rm  -f ${HOME}/deploy/whisk-system/upload.zip
+zip -r ${HOME}/deploy/whisk-system/upload.zip *


### PR DESCRIPTION
This PR provides a new whisk-system/upload action that can be used to upload a single file into the specific user web bucket  available under the context path `/api/v1/web/whisk-system/nuv/upload`

File can be upload via CURL command similar to 

`curl -X PUT -T <local_file_path> -H "minioauth: <auth>" ${APIHOST}/api/v1/web/whisk-system/nuv/upload/<user>/<remote_file_path>`

Examples:

`curl -X PUT -T index2.html -H "minioauth: <auth>" ${APIHOST}/api/v1/web/whisk-system/nuv/upload/nuvolaris/index2.html`

will upload  the file index2.html under the `nuvolaris-web` bucket linked to the `nuvolaris` user

`curl -X PUT -T template.json -H "minioauth: <auth>" ${APIHOST}/api/v1/web/whisk-system/nuv/upload/nuvolaris/.well-known/template.json`

will upload the the file `template.json` under `nuvolaris-wb/.well-known/template.json`



