### PR TITLE
Implements nuvolaris/nuvolaris#301

### DIFF
--- a/deploy/nuvolaris-permissions/whisk-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-crd.yaml
@@ -387,6 +387,15 @@ spec:
                     limits:
                       type: object
                       properties:
+                        activations:
+                          description: control ow activations limits
+                          type: object
+                          properties:
+                            max_allowed_payload:
+                              description: activation max allowed payload size in bytes. Defaults to 1048576 (1MB)
+                              type: integer
+                          required:
+                          - max_allowed_payload  
                         actions:
                           description: control ow actions execution limits
                           type: object

--- a/nuvolaris/ferretdb.py
+++ b/nuvolaris/ferretdb.py
@@ -33,7 +33,7 @@ from nuvolaris.user_config import UserConfig
 from nuvolaris.user_metadata import UserMetadata
 
 def enrich_ferretdb_data(data):
-     data['size']= 1
+     data['size']= cfg.get('mongodb.volume-size') or 10
      data['dir']= "/state"            
      data['storageClass']=cfg.get("nuvolaris.storageclass")
      data['name']="nuvolaris-mongodb"

--- a/nuvolaris/templates/standalone-sts.yaml
+++ b/nuvolaris/templates/standalone-sts.yaml
@@ -162,7 +162,7 @@ spec:
           value: "10m"
 
         - name: "CONFIG_whisk_activation_payload_max"
-          value: "1048576"
+          value: "{{activation_payload_max}}"
 
         - name: "CONFIG_whisk_loadbalancer_blackboxFraction"
           value: "10%"

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -248,6 +248,7 @@ def get_standalone_config_data():
         "actions_sequence_maxLength": cfg.get("configs.limits.actions.sequence-maxLength") or 50,
         "actions_invokes_perMinute": cfg.get("configs.limits.actions.invokes-perMinute") or 60,
         "actions_invokes_concurrent": cfg.get("configs.limits.actions.invokes-concurrent") or 30,
+        "activation_payload_max": cfg.get('configs.limits.activations.max_allowed_payload') or "1048576",
         "time_limit_min": cfg.get("configs.limits.time.limit-min") or "100ms", 
         "time_limit_std": cfg.get("configs.limits.time.limit-std") or "1min", 
         "time_limit_max": cfg.get("configs.limits.time.limit-max") or "5min", 

--- a/tests/gke/whisk.yaml
+++ b/tests/gke/whisk.yaml
@@ -33,11 +33,11 @@ spec:
     # start kafka
     kafka: false
     # start mongodb
-    mongodb: false
+    mongodb: true
     # start redis
-    redis: false
+    redis: true
     # start cron based action parser
-    cron: false
+    cron: true
     # tls enabled or not
     tls: false
     # minio enabled or not
@@ -45,7 +45,7 @@ spec:
     # minio static enabled or not
     static: true
     # postgres enabled or not
-    postgres: false                      
+    postgres: true                      
   openwhisk:
     namespaces:
       whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abcfO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP

--- a/tests/kind/whisk.yaml
+++ b/tests/kind/whisk.yaml
@@ -107,7 +107,7 @@ spec:
       password: s0meP@ass3
   mongodb:
     host: mongodb
-    volume-size: 10
+    volume-size: 5
     admin: 
       user: whisk_admin
       password: 0therPa55

--- a/tests/openshift/whisk.yaml
+++ b/tests/openshift/whisk.yaml
@@ -33,11 +33,11 @@ spec:
     # start kafka
     kafka: false
     # start mongodb
-    mongodb: false
+    mongodb: true
     # start redis
-    redis: false     
+    redis: true     
     # start cron based action parser
-    cron: false 
+    cron: true 
     # tls enabled or not
     tls: false
     # minio enabled or not
@@ -45,7 +45,7 @@ spec:
     # minio static enabled or not
     static: true
     # postgres enabled or not
-    postgres: false            
+    postgres: true            
   openwhisk:
     namespaces:
       whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP


### PR DESCRIPTION
This PR contributes following feature/fixes

- introduces the configs.limits.activations.max_allowed_payload to customize OpenWhisk controller activation max apyalod allowed size in bytes
- fix an issue in ferreted deployer which was not honouring the mongodb.volume-size configuration parameter