### PR TITLE
Supports nuvolaris/nuvolaris#303

### DIFF
--- a/nuvolaris/main.py
+++ b/nuvolaris/main.py
@@ -305,7 +305,8 @@ def whisk_resume(spec, name, **kwargs):
     cfg.detect()
 
     logging.debug("*** dumping resumed configuration parameters")
-    cfg.dump_config()          
+    cfg.dump_config()
+    version_util.annotate_operator_components_version()         
 
 def runtimes_filter(name, type, **kwargs):
     return name == 'openwhisk-runtimes' and type == 'MODIFIED'  


### PR DESCRIPTION
on operator resume annotates again the components version, to take into account scenarios where the updated components it is the operator itself