### PR TITLE
Fixes for nuvolaris/nuvolaris-bugs#22

### DIFF
--- a/actions/Taskfile.yml
+++ b/actions/Taskfile.yml
@@ -111,6 +111,10 @@ tasks:
     - >
       curl -X PUT -T ../nuvolaris/templates/content.html -H "minioauth: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" {{.APIHOST}}/api/v1/web/whisk-system/nuv/upload/nuvolaris/content.html
 
+  upload:chess:
+    - >
+      curl -X PUT -T ../nuvolaris/templates/content.html -H "minioauth: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" {{.APIHOST}}/api/v1/web/whisk-system/nuv/upload/nuvolaris/chess/index.html
+
 
   login:all:
     - task: login:prepare

--- a/nuvolaris/kopf_util.py
+++ b/nuvolaris/kopf_util.py
@@ -16,6 +16,7 @@
 # under the License.
 #
 import json, logging
+import nuvolaris.config as cfg
 
 def normalize(item:tuple):
     """
@@ -42,6 +43,9 @@ def endpoint(response: dict, item: dict):
     """
     if(item['path']=='spec.components.tls' or item['path']=='spec.nuvolaris.apihost'):
         response["endpoint"]="update"
+        # if we update the endpoint we need to be sure that we update also the static if still active
+        if cfg.get('components.static'):
+            response["static"]="update"            
 
 def openwhisk(response: dict, item: dict):
     """

--- a/nuvolaris/templates/nginx-static-cm.yaml
+++ b/nuvolaris/templates/nginx-static-cm.yaml
@@ -33,15 +33,11 @@ data:
       #    index  index.html index.htm;
       #}
 
-      #rewrite ^/$ ${request_uri}index.html break;
-      #rewrite (.*)/$ /$1/index.html;
-      #rewrite ^([^.]*[^/])$ /$1/ permanent;
+      location / {          
+          rewrite ^/$ ${request_uri}index.html break;          
+          rewrite ^([^.]*[^/])$ $1/;
+          rewrite (.*)/$ $1/index.html;                    
 
-      location / {
-          rewrite ^/$ ${request_uri}index.html break;
-          rewrite (.*)/$ $1/index.html;        
-          rewrite ^([^.]*[^/])$ $1/ permanent;
-          
           proxy_hide_header     x-amz-id-2;
           proxy_hide_header     x-amz-meta-etag;
           proxy_hide_header     x-amz-request-id;
@@ -50,10 +46,17 @@ data:
           proxy_set_header Host $http_host;
 
           proxy_pass http://{{minio_host}}.nuvolaris.svc.cluster.local:{{minio_port}}/;
+          
+          error_page 404 @not_found;
+          proxy_intercept_errors on;
           proxy_redirect     off;
-      }      
+      }  
 
-      #error_page  404              /404.html;
+      location @not_found {
+        root   /usr/share/nginx/html;
+      }            
+
+      error_page  404              /404.html;
 
       # redirect server error pages to the static page /50x.html
       #

--- a/tests/kind/whisk-minimal.yaml
+++ b/tests/kind/whisk-minimal.yaml
@@ -1,0 +1,134 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: nuvolaris.org/v1
+kind: Whisk
+metadata:
+  name: controller
+  namespace: nuvolaris
+spec: 
+  components:
+    # start openwhisk controller
+    openwhisk: true
+    # start openwhisk invoker
+    invoker: false    
+    # start couchdb
+    couchdb: true
+    # start kafka
+    kafka: false
+    # start mongodb
+    mongodb: false
+    # start redis
+    redis: false      
+    # start cron based action parser
+    cron: false 
+    # tls enabled or not
+    tls: false
+    # minio enabled or not
+    minio: true 
+    # minio static enabled or not
+    static: true
+    # postgres enabled or not
+    postgres: false          
+  openwhisk:
+    namespaces:
+      whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
+      nuvolaris: cbd68075-dac2-475e-8c07-d62a30c7e683:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
+#  controller:
+#    image: "ghcr.io/nuvolaris/openwhisk-controller:0.3.0-morpheus.22122609"    
+  nuvolaris:
+    storageclass: auto #standard
+    provisioner: auto #rancher.io/local-path
+    ingressclass: auto #nginx
+    ingresslb: auto #ingress-nginx/ingress-nginx-controller
+  couchdb:
+    host: couchdb
+    port: 5984
+    volume-size: 10
+    admin:
+      user: whisk_admin
+      password: some_passw0rd
+    controller:
+      user: invoker_admin
+      password: s0meP@ass1
+    invoker:
+      user: controller_admin
+      password: s0meP@ass2
+  kafka:
+    host: kafka
+    volume-size: 10
+  scheduler:
+    schedule: "* * * * *"
+  tls:
+    acme-registered-email: francesco@nuvolaris.io
+    acme-server-url: https://acme-staging-v02.api.letsencrypt.org/directory
+  configs:
+    limits:
+      actions:
+        sequence-maxLength: 50
+        invokes-perMinute: 999
+        invokes-concurrent: 250
+      triggers: 
+        fires-perMinute: 999
+    controller:
+      javaOpts: "-Xmx2048M"
+      #resources:
+      #  cpu-req: "500m"
+      #  cpu-lim: "1"
+      #  mem-req: "1G"
+      #  mem-lim: "2G"
+    #couchdb:
+      #resources:
+        #cpu-req: "500m"
+        #cpu-lim: "1"
+        #mem-req: "512M"
+        #mem-lim: "1G"        
+  redis:
+    persistence-enabled: true
+    volume-size: 10
+    default:
+      password: s0meP@ass3
+    nuvolaris:
+      #prefix: nuvolaris      
+      password: s0meP@ass3
+  mongodb:
+    host: mongodb
+    volume-size: 5
+    admin: 
+      user: whisk_admin
+      password: 0therPa55
+    nuvolaris:
+      user: nuvolaris
+      password: s0meP@ass3
+    exposedExternally: False
+    useOperator: False
+  minio:
+    volume-size: 2
+    admin:
+      user: minioadmin
+      password: minioadmin    
+    nuvolaris:
+      user: nuvolaris
+      password: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
+  postgres:    
+    volume-size: 5
+    replicas: 2
+    admin:      
+      password: 0therPa55
+      replica-password: 0therPa55RR
+    nuvolaris:
+      password: s0meP@ass3                   


### PR DESCRIPTION
This PR fixes the following issues

1. enabling tis to activate https endpoint was not updating static ingress, if static was enabled too
2. improves nginx static rewrite rule to handle properly GET request for subfolders inside the user web bucket requesting by default the folder/index.html file, unless the requested URL contains a . in such case it is considered a GET for a specific file.
3. It redirects 404 error from MINIO returning from MINIO for non existing resources to the internal nginx pages, to hide completely the fact that the nginx-static it is a MINIO proxy