### PR TITLE
fix: update to .gitignore to include nuv devel action __main__.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ clusters/worker.yaml
 run.pid
 *.off
 actions/*/nuvolaris/
-!actions/*/__main__.py
+!actions/**/__main__.py
 _*.yaml
 apihost.txt
 .git-hooks/

--- a/actions/devel/download/__main__.py
+++ b/actions/devel/download/__main__.py
@@ -1,0 +1,91 @@
+import os
+import base64
+import random
+import string
+import mimetypes
+import io
+
+import common.minio_util as mutil
+import common.util as ut
+
+from common.authorize import Authorize
+
+def build_error(message: str):
+    return {
+        "statusCode": 400,
+        "body": message
+    }
+
+def build_response(filename, content_type, buffer):
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type":content_type, "Content-Disposition": f"inline; filename='{filename}'"},
+        "body": buffer.getvalue().decode()
+    }
+
+
+def process_path_param(ow_path: str):
+    """ Process the __ow_path parameters to extract username and fully qualified filename
+
+    :parma ow_path, the __ow_path parameter passed by openwhisk action controller
+    :return a dictionary {bucket:<bucket>, filename:<filepath>}
+    """
+    path_params = ow_path
+    if ow_path.startswith("/"):
+        path_params = ow_path[1:None]
+
+    path_elements = path_params.split("/")
+
+    upload_data = {}
+
+    if len(path_elements) >= 1:
+        upload_data['bucket']=path_elements[0]
+        upload_data['path']=path_params.replace(f"{upload_data['bucket']}/","")
+
+        file_elements = upload_data['path'].split("/")
+
+        if len(file_elements) > 1:
+           upload_data['filename']=file_elements[len(file_elements)-1]
+        else:
+           upload_data['filename']=file_elements
+
+    return upload_data
+
+
+def main(args):
+    """
+    Action implementing a generic download wrapper for the nuv devel plugin. The invoker must provide a x-impersonate-auth header containing the Openwhisk BASIC authentication of the wsku/user the action should impersonate 
+    when calling this action. The upload action it is supposed to receive a path param similar to /<bucket>/<path>
+    and will attempt to retrieve the given path under the given MINIO <bucket>. The bucket must exists and the impersonated user must have read permission on it.
+    """
+    headers = args['__ow_headers']
+    if('x-impersonate-auth' not in headers):
+        return build_error("invalid request, missing mandatory header: x-impersonate-auth")
+
+    try:        
+        download_data = process_path_param(args['__ow_path'])
+
+        if 'bucket' not in download_data and 'filename' not in download_data:
+            return build_error("invalid request, bucket and/or filename path error")
+        
+        print(f"processing request to download {download_data['path']} from bucket {download_data['bucket']}")
+        user_data = Authorize(args['couchdb_host'],args['couchdb_user'],args['couchdb_password']).login(headers['x-impersonate-auth'])                   
+
+        mo_client = mutil.build_mo_client(ut.get_env_value(user_data,"MINIO_HOST"), ut.get_env_value(user_data,"MINIO_PORT"),ut.get_env_value(user_data,"MINIO_ACCESS_KEY")  , ut.get_env_value(user_data,"MINIO_SECRET_KEY"))
+
+        # see https://urllib3.readthedocs.io/en/latest/reference/urllib3.response.html for the format       
+        response = mo_client.get_object(bucket_name = download_data['bucket'], object_name= download_data['path'])
+                
+        content_type = response.getheader('Content-Type')
+        buffer = io.BytesIO()
+
+        for d in response.stream():
+            buffer.write(d)
+
+        return build_response(download_data['filename'], content_type, buffer)        
+    except Exception as e:       
+        return build_error(f"failed to execute nuv devel command. Reason: {e}")
+    finally:
+        if response:
+            response.close()
+            response.release_conn()

--- a/actions/devel/ferretdb/__main__.py
+++ b/actions/devel/ferretdb/__main__.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import json
+
+from common.authorize import Authorize
+from common.command_data import CommandData
+from command.ferretbd import FerretDB
+from base64 import b64decode
+
+class ApiError(Exception):
+    pass
+
+def build_error(message: str):
+    return {
+        "statusCode": 400,
+        "body": message
+    }
+
+def build_response(data:CommandData):
+    meta_data = data.get_metadata()
+    return {
+        "statusCode": meta_data['status'],
+        "body": meta_data['result']
+    }
+
+def parse_body(args):
+    try:
+        return b64decode(args['__ow_body']).decode().strip()        
+    except Exception as e:
+        print(e)
+        raise ApiError("could not parse __ow_body as base64")
+
+def main(args):
+    """
+    Action implementing a generic command wrapper for the nuv devel mdb/ferretdb plugin. The action must be called with a POST request receiving a JSON
+    payload similar to this one
+    {
+        "command":"SET nuvolaris:key1 donald_duck"
+    }
+
+    the invoker must provide a x-impersonate-auth header containing the Openwhisk BASIC authentication of the wsku/user the action should impersonate 
+    when submitting the command. Every specific provider will support specific request type and command.
+    WARNING: the body will be received as base64 encoded string as this action will be deployed with --web raw enabled flag
+    """
+    print(args)
+    headers = args['__ow_headers']
+    if('x-impersonate-auth' not in headers):
+        return build_error("invalid request, missing mandatory header: x-impersonate-auth")
+
+    if(len(args['__ow_body']) == 0):
+        return build_error("invalid request, no command payload received")
+    
+    try:        
+        user_data = Authorize(args['couchdb_host'],args['couchdb_user'],args['couchdb_password']).login(headers['x-impersonate-auth'])               
+        cmd = CommandData(json.loads(parse_body(args)))           
+        return build_response(FerretDB(user_data).execute(cmd))
+    except Exception as e:        
+        return build_error(f"failed to execute nuv devel ferretdb. Reason: {str(e)}")

--- a/actions/devel/minio/__main__.py
+++ b/actions/devel/minio/__main__.py
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import nuvolaris.config as cfg
+import nuvolaris.couchdb_util as cu
+import logging, json
+
+from common.authorize import Authorize
+from command.minio import Minio
+from common.command_data import CommandData
+from base64 import b64decode
+
+class ApiError(Exception):
+    pass
+
+def build_error(message: str):
+    return {
+        "statusCode": 400,
+        "body": message
+    }
+
+def build_response(data:CommandData):
+    meta_data = data.get_metadata()
+    return {
+        "statusCode": meta_data['status'],
+        "body": meta_data['result']
+    }
+
+def parse_body(args):
+    try:
+        return b64decode(args['__ow_body']).decode().strip()        
+    except Exception as e:
+        print(e)
+        raise ApiError("could not parse __ow_body as base64")
+
+def main(args):
+    """
+    Action implementing a generic command wrapper for the nuv devel plugin. The action must be called with a POST request receiving a JSON
+    payload similar to this one
+    {
+        "command":"ls",
+        "args":[
+            "<bucket-name>"
+        ]
+    }
+
+    the invoker must provide a x-impersonate-auth header containing the Openwhisk BASIC authentication of the wsku/user the action should impersonate 
+    when submitting the command. Every specific provider will support specific request type and command.
+    WARNING: the body will be received as base64 encoded string as this action will be deployed with --web raw enabled flag
+    """
+    headers = args['__ow_headers']
+    if('x-impersonate-auth' not in headers):
+        return build_error("invalid request, missing mandatory header: x-impersonate-auth")
+
+    if(len(args['__ow_body']) == 0):
+        return build_error("invalid request, no command payload received")
+    
+    try:        
+        user_data = Authorize(args['couchdb_host'],args['couchdb_user'],args['couchdb_password']).login(headers['x-impersonate-auth'])               
+        cmd = CommandData(json.loads(parse_body(args)))          
+        return build_response(Minio(user_data).execute(cmd))
+    except Exception as e:        
+        return build_error(f"failed to execute nuv devel minio. Reason: {str(e)}")

--- a/actions/devel/psql/__main__.py
+++ b/actions/devel/psql/__main__.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import nuvolaris.config as cfg
+import nuvolaris.couchdb_util as cu
+import logging, json
+
+from common.authorize import Authorize
+from common.command_data import CommandData
+from command.psql import Psql
+from base64 import b64decode
+
+class ApiError(Exception):
+    pass
+
+def build_error(message: str):
+    return {
+        "statusCode": 400,
+        "body": message
+    }
+
+def build_response(data:CommandData):
+    meta_data = data.get_metadata()
+    return {
+        "statusCode": meta_data['status'],
+        "body": meta_data['result']
+    }
+
+def parse_body(args):
+    try:
+        return b64decode(args['__ow_body']).decode().strip()        
+    except Exception as e:
+        print(e)
+        raise ApiError("could not parse __ow_body as base64")
+
+def main(args):
+    """
+    Action implementing a generic command wrapper for the nuv devel plugin. The action must be called with a POST request receiving a JSON
+    payload similar to this one
+    {
+        "command":"select * from table"
+    }
+
+    the invoker must provide a x-impersonate-auth header containing the Openwhisk BASIC authentication of the wsku/user the action should impersonate
+    when submitting the command. Every specific provider will support specific request type and command.
+    WARNING: the body will be received as base64 encoded string as this action will be deployed with --web raw enabled flag
+    """
+    headers = args['__ow_headers']
+    if('x-impersonate-auth' not in headers):
+        return build_error("invalid request, missing mandatory header: x-impersonate-auth")
+
+    if(len(args['__ow_body']) == 0):
+        return build_error("invalid request, no command payload received")
+    
+    try:        
+        user_data = Authorize(args['couchdb_host'],args['couchdb_user'],args['couchdb_password']).login(headers['x-impersonate-auth'])               
+        cmd = CommandData(json.loads(parse_body(args)))
+        return build_response(Psql(user_data).execute(cmd))
+    except Exception as e:        
+        return build_error(f"failed to execute nuv devel psql. Reason: {str(e)}")

--- a/actions/devel/redis/__main__.py
+++ b/actions/devel/redis/__main__.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import json
+
+from common.authorize import Authorize
+from common.command_data import CommandData
+from command.redis import Redis
+from base64 import b64decode
+
+class ApiError(Exception):
+    pass
+
+def build_error(message: str):
+    return {
+        "statusCode": 400,
+        "body": message
+    }
+
+def build_response(data:CommandData):
+    meta_data = data.get_metadata()
+    return {
+        "statusCode": meta_data['status'],
+        "body": meta_data['result']
+    }
+
+def parse_body(args):
+    try:
+        return b64decode(args['__ow_body']).decode().strip()        
+    except Exception as e:
+        print(e)
+        raise ApiError("could not parse __ow_body as base64")
+
+def main(args):
+    """
+    Action implementing a generic command wrapper for the nuv devel plugin. The action must be called with a POST request receiving a JSON
+    payload similar to this one
+    {
+        "command":"SET nuvolaris:key1 donald_duck"
+    }
+
+    the invoker must provide a x-impersonate-auth header containing the Openwhisk BASIC authentication of the wsku/user the action should impersonate 
+    when submitting the command. Every specific provider will support specific request type and command.
+    WARNING: the body will be received as base64 encoded string as this action will be deployed with --web raw enabled flag
+    """
+    headers = args['__ow_headers']
+    if('x-impersonate-auth' not in headers):
+        return build_error("invalid request, missing mandatory header: x-impersonate-auth")
+
+    if(len(args['__ow_body']) == 0):
+        return build_error("invalid request, no command payload received")
+    
+    try:        
+        user_data = Authorize(args['couchdb_host'],args['couchdb_user'],args['couchdb_password']).login(headers['x-impersonate-auth'])               
+        cmd = CommandData(json.loads(parse_body(args)))           
+        return build_response(Redis(user_data).execute(cmd))
+    except Exception as e:        
+        return build_error(f"failed to execute nuv devel redis. Reason: {str(e)}")

--- a/actions/devel/upload/__main__.py
+++ b/actions/devel/upload/__main__.py
@@ -1,0 +1,89 @@
+import os
+import base64
+import random
+import string
+import mimetypes
+
+import common.minio_util as mutil
+import common.util as ut
+
+from common.authorize import Authorize
+
+def build_error(message: str):
+    return {
+        "statusCode": 400,
+        "body": message
+    }
+
+def build_response(user, filename,bucket, upload_result, upload_message):
+    body = {
+        "user":user,
+        "filename":filename,
+        "bucket":bucket,
+        "uploaded": upload_result
+    }
+
+    if upload_message:
+        body['message']=upload_message
+
+    return {
+        "statusCode": upload_result and 200 or 400,
+        "body": body
+    }
+
+
+def process_path_param(ow_path: str):
+    """ Process the __ow_path parameters to extract username and fully qualified filename
+
+    :parma ow_path, the __ow_path parameter passed by openwhisk action controller
+    :return a dictionary {bucket:<bucket>, filename:<filepath>}
+    """
+    path_params = ow_path
+    if ow_path.startswith("/"):
+        path_params = ow_path[1:None]
+
+    path_elements = path_params.split("/")
+
+    upload_data = {}
+
+    if len(path_elements) >= 1:
+        upload_data['bucket']=path_elements[0]
+        upload_data['filename']=path_params.replace(f"{upload_data['bucket']}/","")
+
+    return upload_data
+
+
+def main(args):
+    """
+    Action implementing a generic upload wrapper for the nuv devel plugin. The invoker must provide a x-impersonate-auth header containing the Openwhisk BASIC authentication of the wsku/user the action should impersonate 
+    when calling this action. The upload action it is supposed to receive a path param similar to /<bucket>/<path>
+    and will store the given path under the given MINIO <bucket>. The bucket must exists and the impersonated user must have write permission on it.
+    """
+    headers = args['__ow_headers']
+    if('x-impersonate-auth' not in headers):
+        return build_error("invalid request, missing mandatory header: x-impersonate-auth")
+    
+    if(len(args['__ow_body']) == 0):
+        return build_error("invalid request, no file content has been received")
+
+    try:        
+        upload_data = process_path_param(args['__ow_path'])
+
+        if 'bucket' not in upload_data and 'filename' not in upload_data:
+            return build_error("invalid request, bucket and/or filename path error")
+        
+        content_as_b64 = args['__ow_body']
+
+        user_data = Authorize(args['couchdb_host'],args['couchdb_user'],args['couchdb_password']).login(headers['x-impersonate-auth'])                   
+        print(f"processing request to upload file {upload_data['filename']}")
+
+        mo_client = mutil.build_mo_client(ut.get_env_value(user_data,"MINIO_HOST"), ut.get_env_value(user_data,"MINIO_PORT"),ut.get_env_value(user_data,"MINIO_ACCESS_KEY")  , ut.get_env_value(user_data,"MINIO_SECRET_KEY"))
+        tmp_file = mutil.prepare_file_upload(user_data['login'],upload_data['filename'],content_as_b64)
+
+        if tmp_file:        
+            upload_result, upload_message = mutil.upload_file(mo_client,tmp_file,upload_data['bucket'],upload_data['filename'])
+            return build_response(user_data['login'],upload_data['filename'],upload_data['bucket'],upload_result, upload_message)
+        else:
+            return build_error("Unexptected error upload action. Check activation log")
+    except Exception as e:        
+        return build_error(f"failed to execute nuv devel command. Reason: {e}")


### PR DESCRIPTION
fix in the .gitignore to include all the __main__.py under the actions folder. Previous configuration systematically excluded the nuv devel actions codebase.