### PR TITLE
fix: upload action assign application/yaml mimetype to .yaml and .yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ clusters/worker.yaml
 *.kubeconfig
 run.pid
 *.off
-actions/*/nuvolaris/
+actions/**/nuvolaris/
 !actions/**/__main__.py
 _*.yaml
 apihost.txt

--- a/actions/Taskfile.yml
+++ b/actions/Taskfile.yml
@@ -264,6 +264,10 @@ tasks:
     - >
       curl -X PUT -T ../nuvolaris/templates/content.html -H "minioauth: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" {{.APIHOST}}/api/v1/web/whisk-system/nuv/upload/nuvolaris/tidy/content.html
 
+  upload:yaml:
+    - >
+      curl -X PUT -T ../nuvolaris/templates/couchdb-init.yaml -H "minioauth: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" {{.APIHOST}}/api/v1/web/whisk-system/nuv/upload/nuvolaris/yaml/couchdb-init.yaml      
+
   upload:chess:
     - >
       curl -X PUT -T ../nuvolaris/templates/content.html -H "minioauth: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" {{.APIHOST}}/api/v1/web/whisk-system/nuv/upload/nuvolaris/chess/index.html

--- a/actions/common/minio_util.py
+++ b/actions/common/minio_util.py
@@ -27,7 +27,13 @@ from minio.error import S3Error
 from minio.commonconfig import CopySource
 
 def extract_mimetype(file):
-    mimetype, _ = mimetypes.guess_type(file)
+
+    # python mymetype does does not support yet yaml files
+    if ".yaml" in file.lower() or ".yml" in file.lower():
+        mimetype = "application/yaml"
+    else:    
+        mimetype, _ = mimetypes.guess_type(file)
+        
     if mimetype is None:
         raise Exception(f"Failed to guess mimetype for {file}")
     else:

--- a/actions/devel/download/common/minio_util.py
+++ b/actions/devel/download/common/minio_util.py
@@ -27,7 +27,13 @@ from minio.error import S3Error
 from minio.commonconfig import CopySource
 
 def extract_mimetype(file):
-    mimetype, _ = mimetypes.guess_type(file)
+
+    # python mymetype does does not support yet yaml files
+    if ".yaml" in file.lower() or ".yml" in file.lower():
+        mimetype = "application/yaml"
+    else:    
+        mimetype, _ = mimetypes.guess_type(file)
+        
     if mimetype is None:
         raise Exception(f"Failed to guess mimetype for {file}")
     else:

--- a/actions/devel/ferretdb/common/minio_util.py
+++ b/actions/devel/ferretdb/common/minio_util.py
@@ -27,7 +27,13 @@ from minio.error import S3Error
 from minio.commonconfig import CopySource
 
 def extract_mimetype(file):
-    mimetype, _ = mimetypes.guess_type(file)
+
+    # python mymetype does does not support yet yaml files
+    if ".yaml" in file.lower() or ".yml" in file.lower():
+        mimetype = "application/yaml"
+    else:    
+        mimetype, _ = mimetypes.guess_type(file)
+        
     if mimetype is None:
         raise Exception(f"Failed to guess mimetype for {file}")
     else:

--- a/actions/devel/minio/common/minio_util.py
+++ b/actions/devel/minio/common/minio_util.py
@@ -27,7 +27,13 @@ from minio.error import S3Error
 from minio.commonconfig import CopySource
 
 def extract_mimetype(file):
-    mimetype, _ = mimetypes.guess_type(file)
+
+    # python mymetype does does not support yet yaml files
+    if ".yaml" in file.lower() or ".yml" in file.lower():
+        mimetype = "application/yaml"
+    else:    
+        mimetype, _ = mimetypes.guess_type(file)
+        
     if mimetype is None:
         raise Exception(f"Failed to guess mimetype for {file}")
     else:

--- a/actions/devel/psql/common/minio_util.py
+++ b/actions/devel/psql/common/minio_util.py
@@ -27,7 +27,13 @@ from minio.error import S3Error
 from minio.commonconfig import CopySource
 
 def extract_mimetype(file):
-    mimetype, _ = mimetypes.guess_type(file)
+
+    # python mymetype does does not support yet yaml files
+    if ".yaml" in file.lower() or ".yml" in file.lower():
+        mimetype = "application/yaml"
+    else:    
+        mimetype, _ = mimetypes.guess_type(file)
+        
     if mimetype is None:
         raise Exception(f"Failed to guess mimetype for {file}")
     else:
@@ -177,5 +183,5 @@ def mv_file(mo_client, orig_bucket, orig_file, dest_bucket, dest_file):
     except Exception as e:
         print(e)
         return None
-    return None                          
+    return None                             
 

--- a/actions/devel/redis/common/minio_util.py
+++ b/actions/devel/redis/common/minio_util.py
@@ -27,7 +27,13 @@ from minio.error import S3Error
 from minio.commonconfig import CopySource
 
 def extract_mimetype(file):
-    mimetype, _ = mimetypes.guess_type(file)
+
+    # python mymetype does does not support yet yaml files
+    if ".yaml" in file.lower() or ".yml" in file.lower():
+        mimetype = "application/yaml"
+    else:    
+        mimetype, _ = mimetypes.guess_type(file)
+        
     if mimetype is None:
         raise Exception(f"Failed to guess mimetype for {file}")
     else:
@@ -177,5 +183,5 @@ def mv_file(mo_client, orig_bucket, orig_file, dest_bucket, dest_file):
     except Exception as e:
         print(e)
         return None
-    return None                          
+    return None                             
 

--- a/actions/devel/upload/common/minio_util.py
+++ b/actions/devel/upload/common/minio_util.py
@@ -27,7 +27,13 @@ from minio.error import S3Error
 from minio.commonconfig import CopySource
 
 def extract_mimetype(file):
-    mimetype, _ = mimetypes.guess_type(file)
+
+    # python mymetype does does not support yet yaml files
+    if ".yaml" in file.lower() or ".yml" in file.lower():
+        mimetype = "application/yaml"
+    else:    
+        mimetype, _ = mimetypes.guess_type(file)
+        
     if mimetype is None:
         raise Exception(f"Failed to guess mimetype for {file}")
     else:

--- a/actions/upload/common/minio_util.py
+++ b/actions/upload/common/minio_util.py
@@ -27,7 +27,13 @@ from minio.error import S3Error
 from minio.commonconfig import CopySource
 
 def extract_mimetype(file):
-    mimetype, _ = mimetypes.guess_type(file)
+
+    # python mymetype does does not support yet yaml files
+    if ".yaml" in file.lower() or ".yml" in file.lower():
+        mimetype = "application/yaml"
+    else:    
+        mimetype, _ = mimetypes.guess_type(file)
+        
     if mimetype is None:
         raise Exception(f"Failed to guess mimetype for {file}")
     else:


### PR DESCRIPTION
This PR fixes an issue in the upload system action which was not able to upload .yaml or .yml file, as the python mymetype library does not recognise such type of extension, and apparently there is not yer an official RFC.

The upload action will assign application/yaml mime type which seems to be the one mostly supported by browsers.