### PR TITLE
on_resume handler redeploys also system actions

### DIFF
--- a/nuvolaris/whisk_actions_deployer.py
+++ b/nuvolaris/whisk_actions_deployer.py
@@ -194,10 +194,13 @@ def safe_deploy(wskClient):
     return True
 
 def deploy_whisk_system_action():
-    auth = cfg.get('openwhisk.namespaces.whisk-system')
-    data = prepare_system_actions()
-    tplres = kust.processTemplate("whisk-system","whisk-system-manifest-tpl.yaml",data,"manifest.yaml")
+    try:
+        auth = cfg.get('openwhisk.namespaces.whisk-system')
+        data = prepare_system_actions()
+        tplres = kust.processTemplate("whisk-system","whisk-system-manifest-tpl.yaml",data,"manifest.yaml")
 
-    wskClient = WhiskSystemClient(auth)
-    result = safe_deploy(wskClient)
-    return result
+        wskClient = WhiskSystemClient(auth)
+        result = safe_deploy(wskClient)
+        return result
+    except Exception as e:
+        logging.error("Error detected when deploying system actions", e)


### PR DESCRIPTION
This PR contributes an improvement in the operator on_resume handler.

This handler it is normally triggered by a nuv update operator command, and one of the reason to update the operator it is to redeploy an updated version of the system action or even newer system actions. 