### PR TITLE
Implements nuvolaris/nuvolaris#350

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,7 +22,7 @@ vars:
   N: ""
   T: ""
   P: ""
-  BASETAG: 3.0.0-beta
+  BASETAG: 3.1.0-mastrogpt
   KUBE:
     sh: ./detect.sh
   NS: "nuvolaris"

--- a/deploy/nuvolaris-permissions/whisk-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-crd.yaml
@@ -77,10 +77,10 @@ spec:
                     ingresslb:
                       description: allow to set the location of the ingress lb in the form namespace/service-name. Default to auto which will force the operator to use default values based on the environment.
                       type: string
-                    affinity-enabled:
+                    affinity:
                       description: enable/disable openwhisk configuration with node affinity. This flag can be true only on multinode cluster deployment. Default to false
                       type: boolean
-                    toleration-enabled:
+                    tolerations:
                       description: enable/disable openwhisk toleration. This flag can be true only on multinode cluster deployment. Default to false
                       type: boolean                                                                                                                 
                   required:

--- a/deploy/openwhisk-standalone/standalone-sts.yaml
+++ b/deploy/openwhisk-standalone/standalone-sts.yaml
@@ -18,6 +18,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: controller
+  namespace: nuvolaris
   labels:
     name: controller
     app: controller

--- a/deploy/postgres-operator-deploy/postgres.yaml
+++ b/deploy/postgres-operator-deploy/postgres.yaml
@@ -26,7 +26,7 @@ spec:
    image: postgres:14.1
    database:
       size: 200Mi
-   customConfig: nuvolaris-postgres-conf 
+   customConfig: nuvolaris-postgres-conf    
    env:
       - name: POSTGRES_PASSWORD
         valueFrom:

--- a/nuvolaris/ferretdb.py
+++ b/nuvolaris/ferretdb.py
@@ -42,6 +42,7 @@ def enrich_ferretdb_data(data):
      
      # use nuvolaris postgres db as default configuration for FERRETDB
      data['ferretdb_postgres_url'] = postgres.get_base_postgres_url(data)
+     util.ferretb_affinity_tolerations_data(data)
 
 def create(owner=None):
     """
@@ -53,6 +54,9 @@ def create(owner=None):
     enrich_ferretdb_data(data)
 
     tplp = ["security-set-attach.yaml","set-attach.yaml","ferretdb-sts.yaml"]
+    if(data['affinity'] or data['tolerations']):
+       tplp.append("affinity-tolerance-sts-core-attach.yaml")
+           
     mkust = kus.patchTemplates("ferretdb", tplp, data)    
     mspec = kus.kustom_list("ferretdb", mkust, templates=[], data=data)
 

--- a/nuvolaris/minio.py
+++ b/nuvolaris/minio.py
@@ -69,7 +69,7 @@ def create(owner=None):
     tplp = ["00-minio-pvc.yaml","01-minio-dep.yaml","02-minio-svc.yaml"]
 
     if(data['affinity'] or data['tolerations']):
-       tplp.append("affinity-tolerance-sts-core-attach.yaml")    
+       tplp.append("affinity-tolerance-dep-core-attach.yaml")    
 
     kust = kus.patchTemplates("minio", tplp, data)
     spec = kus.kustom_list("minio", kust, templates=[], data=data)

--- a/nuvolaris/minio.py
+++ b/nuvolaris/minio.py
@@ -68,6 +68,9 @@ def create(owner=None):
 
     tplp = ["00-minio-pvc.yaml","01-minio-dep.yaml","02-minio-svc.yaml"]
 
+    if(data['affinity'] or data['tolerations']):
+       tplp.append("affinity-tolerance-sts-core-attach.yaml")    
+
     kust = kus.patchTemplates("minio", tplp, data)
     spec = kus.kustom_list("minio", kust, templates=[], data=data)
 

--- a/nuvolaris/minio_static.py
+++ b/nuvolaris/minio_static.py
@@ -30,18 +30,11 @@ from nuvolaris.route_data import RouteData
 def create(owner=None):
     logging.info(f"*** configuring nuvolaris nginx static provider")
     runtime = cfg.get('nuvolaris.kube')
-    data = {
-        "name":"nuvolaris-static",
-        "container":"nuvolaris-static",
-        "size":1,
-        "storageClass": cfg.get('nuvolaris.storageclass'),
-        "dir":"/var/cache/nginx",
-        "minio_host": cfg.get('minio.host') or "minio",
-        "minio_port": cfg.get('minio.port') or "9000",
-        "applypodsecurity": util.get_enable_pod_security()
-    }
-    
+    data = util.get_minio_static_config_data()    
     tplp = ["nginx-static-cm.yaml","nginx-static-sts.yaml","security-set-attach.yaml","set-attach.yaml"]
+
+    if(data['affinity'] or data['tolerations']):
+       tplp.append("affinity-tolerance-sts-core-attach.yaml")     
 
     kust = kus.patchTemplates("nginx-static", tplp, data)    
     spec = kus.kustom_list("nginx-static", kust, templates=[], data=data)

--- a/nuvolaris/openwhisk_standalone.py
+++ b/nuvolaris/openwhisk_standalone.py
@@ -31,9 +31,14 @@ def create(owner=None):
 
     whisk_image = data["controller_image"]
     whisk_tag = data["controller_tag"]
+    
+    tplp = ["set-attach.yaml"]
+    if(data['affinity'] or data['tolerations']):
+       tplp.append("affinity-tolerance-sts-core-attach.yaml") 
+
 
     config = kus.image(whisk_image, newTag=whisk_tag)
-    config += kus.patchTemplates("openwhisk-standalone", ["standalone-sts.yaml"], data) 
+    config += kus.patchTemplates("openwhisk-standalone", tplp, data) 
     spec = kus.kustom_list("openwhisk-standalone", config, templates=[], data=data)
 
     if owner:

--- a/nuvolaris/openwhisk_standalone.py
+++ b/nuvolaris/openwhisk_standalone.py
@@ -31,14 +31,13 @@ def create(owner=None):
 
     whisk_image = data["controller_image"]
     whisk_tag = data["controller_tag"]
-    
-    tplp = ["set-attach.yaml"]
-    if(data['affinity'] or data['tolerations']):
-       tplp.append("affinity-tolerance-sts-core-attach.yaml") 
-
-
     config = kus.image(whisk_image, newTag=whisk_tag)
-    config += kus.patchTemplates("openwhisk-standalone", tplp, data) 
+    
+    tplp = ["standalone-sts.yaml"]
+    if(data['affinity'] or data['tolerations']):
+       tplp.append("affinity-tolerance-sts-core-attach.yaml")
+
+    config += kus.patchTemplates("openwhisk-standalone", tplp, data)
     spec = kus.kustom_list("openwhisk-standalone", config, templates=[], data=data)
 
     if owner:

--- a/nuvolaris/redis.py
+++ b/nuvolaris/redis.py
@@ -61,8 +61,10 @@ def create(owner=None):
     if data['persistence']:
        tplp.append("set-attach.yaml")
 
-    kust = kus.patchTemplates("redis",tplp , data)
-    
+    if(data['affinity'] or data['tolerations']):
+       tplp.append("affinity-tolerance-sts-core-attach.yaml")
+
+    kust = kus.patchTemplates("redis",tplp , data)    
     spec = kus.kustom_list("redis", kust, templates=["redis-conf.yaml"], data=data)
 
     if owner:

--- a/nuvolaris/templates/affinity-tolerance-dep-core-attach.yaml
+++ b/nuvolaris/templates/affinity-tolerance-dep-core-attach.yaml
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{name}}
+  namespace: nuvolaris
+spec:
+  template:
+    spec:
+      affinity:
+      {% if affinity %} 
+        # prefer to not run on an invoker node (only prefer because of single node clusters)
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: nuvolaris-role
+                operator: NotIn
+                values:
+                - {{affinity_invoker_node_label}}
+          - weight: 80
+            preference:
+              matchExpressions:
+              - key: nuvolaris-role
+                operator: In
+                values:
+                - {{affinity_core_node_label}}
+        # Fault tolerance: prevent multiple instances of {{pod_anti_affinity_name}} from running on the same node
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - {{pod_anti_affinity_name}}
+            topologyKey: "kubernetes.io/hostname"
+      {% endif %}               
+      tolerations:
+      {% if tolerations %}   
+        - key: "nuvolaris-role"
+          operator: "Equal"
+          value: {{toleration_role}}
+          effect: "NoSchedule"
+      {% endif %}            

--- a/nuvolaris/templates/affinity-tolerance-sts-core-attach.yaml
+++ b/nuvolaris/templates/affinity-tolerance-sts-core-attach.yaml
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{name}}
+  namespace: nuvolaris
+spec:
+  template:
+    spec:
+      affinity:
+      {% if affinity %} 
+        # prefer to not run on an invoker node (only prefer because of single node clusters)
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: nuvolaris-role
+                operator: NotIn
+                values:
+                - {{affinity_invoker_node_label}}
+          - weight: 80
+            preference:
+              matchExpressions:
+              - key: nuvolaris-role
+                operator: In
+                values:
+                - {{affinity_core_node_label}}
+        # Fault tolerance: prevent multiple instances of {{pod_anti_affinity_name}} from running on the same node
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - {{pod_anti_affinity_name}}
+            topologyKey: "kubernetes.io/hostname"
+      {% endif %}               
+      tolerations:
+      {% if tolerations %}   
+        - key: "nuvolaris-role"
+          operator: "Equal"
+          value: {{toleration_role}}
+          effect: "NoSchedule"
+      {% endif %}            

--- a/nuvolaris/templates/affinity-tolerance-sts-invoker-attach.yaml
+++ b/nuvolaris/templates/affinity-tolerance-sts-invoker-attach.yaml
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{name}}
+  namespace: nuvolaris
+spec:
+  template:
+    spec:
+      affinity:
+      {% if affinity %}
+        # run only on nodes labeled with nuvolaris-role={{affinity_invoker_node_label}}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nuvolaris-role
+                operator: In
+                values:
+                - {{affinity_invoker_node_label}}
+        # Fault tolerance: prevent multiple instances of {{pod-anti-affinity-name}} from running on the same node
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - {{pod_anti_affinity_name}}
+            topologyKey: "kubernetes.io/hostname"
+      {% endif %}      
+      tolerations:
+      {% if tolerations %}
+        - key: "nuvolaris-role"
+          operator: "Equal"
+          value: {{toleration_role}}
+          effect: "NoSchedule"
+      {% endif %}    

--- a/nuvolaris/templates/postgres.yaml
+++ b/nuvolaris/templates/postgres.yaml
@@ -27,7 +27,35 @@ spec:
    database:
       size: {{size}}Gi
       storageClassName: {{storageClass}}
-   customConfig: nuvolaris-postgres-conf 
+   customConfig: nuvolaris-postgres-conf
+   scheduler:
+      affinity:
+      {% if affinity %}
+        # prefer to not run on an invoker node (only prefer because of single node clusters)
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: nuvolaris-role
+                operator: NotIn
+                values:
+                - {{affinity_invoker_node_label}}
+          - weight: 80
+            preference:
+              matchExpressions:
+              - key: nuvolaris-role
+                operator: In
+                values:
+                - {{affinity_core_node_label}}
+      {% endif %}               
+      tolerations:
+      {% if tolerations %}   
+        - key: "nuvolaris-role"
+          operator: "Equal"
+          value: {{toleration_role}}
+          effect: "NoSchedule"
+      {% endif %}   
    env:
       - name: POSTGRES_PASSWORD
         valueFrom:

--- a/nuvolaris/templates/standalone-sts.yaml
+++ b/nuvolaris/templates/standalone-sts.yaml
@@ -21,6 +21,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: controller
+  namespace: nuvolaris
   labels:
     name: controller
     app: controller

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -238,6 +238,7 @@ def get_controller_image_data(data):
 # return configuration parameters for the standalone controller
 def get_standalone_config_data():        
     data = {
+        "name":"controller",
         "couchdb_host": cfg.get("couchdb.host") or "couchdb",
         "couchdb_port": cfg.get("couchdb.port") or "5984",
         "couchdb_admin_user": cfg.get("couchdb.admin.user"),
@@ -474,6 +475,16 @@ def ferretb_affinity_tolerations_data(data):
 # populate specific affinity data for ferretdb
 def standalone_affinity_tolerations_data(data):
     common_affinity_tolerations_data(data)
-    data["pod_anti_affinity_name"] = "controller"                    
+    data["pod_anti_affinity_name"] = "controller"
+
+# populate specific affinity data for postgres controller manager
+def postgres_manager_affinity_tolerations_data():
+    data = {
+            "pod_anti_affinity_name":"kubegres-controller-manager",
+            "name":"kubegres-controller-manager" 
+    }
+    common_affinity_tolerations_data(data)
+    return data
+                      
 
     

--- a/tests/k3s/whisk-mysc2.yaml
+++ b/tests/k3s/whisk-mysc2.yaml
@@ -20,7 +20,13 @@ kind: Whisk
 metadata:
   name: controller
   namespace: nuvolaris
-spec: 
+spec:
+  nuvolaris:
+      password: nuvpassw0rd 
+      apihost: arcosicilia.org
+      affinity: true 
+      tolerations: true
+      protocol: https  
   components:
     # start openwhisk controller
     openwhisk: true
@@ -33,31 +39,21 @@ spec:
     # start mongodb
     mongodb: true
     # start redis
-    redis: true      
+    redis: true
     # start cron based action parser
-    cron: false 
-    # tls enabled or not
+    cron: true
+    # enable TLS
     tls: false
     # minio enabled or not
-    minio: true 
+    minio: true
     # minio static enabled or not
     static: true
     # postgres enabled or not
-    postgres: true          
+    postgres: true                    
   openwhisk:
     namespaces:
-      whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
-      nuvolaris: cbd68075-dac2-475e-8c07-d62a30c7e683:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
-#  controller:
-#    image: "ghcr.io/nuvolaris/openwhisk-controller:0.3.0-morpheus.22122609"    
-  nuvolaris:
-    password: nuvpassw0rd  
-    storageclass: auto #standard
-    provisioner: auto #rancher.io/local-path
-    ingressclass: auto #nginx
-    ingresslb: auto #ingress-nginx/ingress-nginx-controller
-    affinity: true 
-    tolerations: true
+      whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abcfO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
+      nuvolaris: cbd68075-dac2-475e-8c07-d62a30c7e683:123zO3xKCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
   couchdb:
     host: couchdb
     port: 5984
@@ -78,7 +74,7 @@ spec:
     schedule: "* * * * *"
   tls:
     acme-registered-email: francesco@nuvolaris.io
-    acme-server-url: https://acme-staging-v02.api.letsencrypt.org/directory
+    acme-server-url: https://acme-v02.api.letsencrypt.org/directory
   configs:
     limits:
       actions:
@@ -89,28 +85,17 @@ spec:
         fires-perMinute: 999
     controller:
       javaOpts: "-Xmx2048M"
-      #resources:
-      #  cpu-req: "500m"
-      #  cpu-lim: "1"
-      #  mem-req: "1G"
-      #  mem-lim: "2G"
-    #couchdb:
-      #resources:
-        #cpu-req: "500m"
-        #cpu-lim: "1"
-        #mem-req: "512M"
-        #mem-lim: "1G"        
   redis:
     persistence-enabled: true
     volume-size: 10
     default:
       password: s0meP@ass3
     nuvolaris:
-      #prefix: nuvolaris      
+      prefix: nuv      
       password: s0meP@ass3
   mongodb:
     host: mongodb
-    volume-size: 5
+    volume-size: 10
     admin: 
       user: whisk_admin
       password: 0therPa55
@@ -126,7 +111,7 @@ spec:
       password: minioadmin    
     nuvolaris:
       user: nuvolaris
-      password: tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
+      password: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
   postgres:    
     volume-size: 5
     replicas: 2
@@ -134,4 +119,5 @@ spec:
       password: 0therPa55
       replica-password: 0therPa55RR
     nuvolaris:
-      password: s0meP@ass3                   
+      password: s0meP@ass3                      
+

--- a/tests/k3s/whisk.yaml
+++ b/tests/k3s/whisk.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   nuvolaris:
       password: nuvpassw0rd 
-      apihost: auto #api.k3s.nuvtest.net
+      apihost: auto #api.k3s.nuvtest.net      
   components:
     # start openwhisk controller
     openwhisk: true

--- a/tests/kind/whisk-affinity.yaml
+++ b/tests/kind/whisk-affinity.yaml
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: nuvolaris.org/v1
+kind: Whisk
+metadata:
+  name: controller
+  namespace: nuvolaris
+spec: 
+  components:
+    # start openwhisk controller
+    openwhisk: true
+    # start openwhisk invoker
+    invoker: false    
+    # start couchdb
+    couchdb: true
+    # start kafka
+    kafka: false
+    # start mongodb
+    mongodb: true
+    # start redis
+    redis: true      
+    # start cron based action parser
+    cron: true 
+    # tls enabled or not
+    tls: false
+    # minio enabled or not
+    minio: true 
+    # minio static enabled or not
+    static: true
+    # postgres enabled or not
+    postgres: true          
+  openwhisk:
+    namespaces:
+      whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
+      nuvolaris: cbd68075-dac2-475e-8c07-d62a30c7e683:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
+#  controller:
+#    image: "ghcr.io/nuvolaris/openwhisk-controller:0.3.0-morpheus.22122609"    
+  nuvolaris:
+    password: nuvpassw0rd  
+    storageclass: auto #standard
+    provisioner: auto #rancher.io/local-path
+    ingressclass: auto #nginx
+    ingresslb: auto #ingress-nginx/ingress-nginx-controller
+    affinity: true 
+    tolerations: true
+  couchdb:
+    host: couchdb
+    port: 5984
+    volume-size: 10
+    admin:
+      user: whisk_admin
+      password: some_passw0rd
+    controller:
+      user: invoker_admin
+      password: s0meP@ass1
+    invoker:
+      user: controller_admin
+      password: s0meP@ass2
+  kafka:
+    host: kafka
+    volume-size: 10
+  scheduler:
+    schedule: "* * * * *"
+  tls:
+    acme-registered-email: francesco@nuvolaris.io
+    acme-server-url: https://acme-staging-v02.api.letsencrypt.org/directory
+  configs:
+    limits:
+      actions:
+        sequence-maxLength: 50
+        invokes-perMinute: 999
+        invokes-concurrent: 250
+      triggers: 
+        fires-perMinute: 999
+    controller:
+      javaOpts: "-Xmx2048M"
+      #resources:
+      #  cpu-req: "500m"
+      #  cpu-lim: "1"
+      #  mem-req: "1G"
+      #  mem-lim: "2G"
+    #couchdb:
+      #resources:
+        #cpu-req: "500m"
+        #cpu-lim: "1"
+        #mem-req: "512M"
+        #mem-lim: "1G"        
+  redis:
+    persistence-enabled: true
+    volume-size: 10
+    default:
+      password: s0meP@ass3
+    nuvolaris:
+      #prefix: nuvolaris      
+      password: s0meP@ass3
+  mongodb:
+    host: mongodb
+    volume-size: 5
+    admin: 
+      user: whisk_admin
+      password: 0therPa55
+    nuvolaris:
+      user: nuvolaris
+      password: s0meP@ass3
+    exposedExternally: False
+    useOperator: False
+  minio:
+    volume-size: 2
+    admin:
+      user: minioadmin
+      password: minioadmin    
+    nuvolaris:
+      user: nuvolaris
+      password: tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
+  postgres:    
+    volume-size: 5
+    replicas: 2
+    admin:      
+      password: 0therPa55
+      replica-password: 0therPa55RR
+    nuvolaris:
+      password: s0meP@ass3                   

--- a/tests/whisk.yaml
+++ b/tests/whisk.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: nuvolaris
 spec:
   nuvolaris:
-    password: nuvpassw0rd 
+    password: nuvpassw0rd
   components:
     # start openwhisk controller
     openwhisk: true


### PR DESCRIPTION
This PR contributes the support for pod segregation going the possibility to enable pod affinity and toleration for these components

- couchdb 
- postgres 
- minio 
- ferretdb 
- minio static 
- standalone controller
- redis 

Affinity and Tolerations won't be enable in the olaris setup, but this is needed as the above components are inherited in the Enterprise version.