### PR TITLE
Implements nuvolaris/projects#113

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,7 @@ ADD deploy/postgres-operator /home/nuvolaris/deploy/postgres-operator
 ADD deploy/postgres-operator-deploy /home/nuvolaris/deploy/postgres-operator-deploy
 ADD deploy/ferretdb /home/nuvolaris/deploy/ferretdb
 ADD deploy/runtimes /home/nuvolaris/deploy/runtimes
+ADD deploy/postgres-backup /home/nuvolaris/deploy/postgres-backup
 ADD run.sh dbinit.sh cron.sh pyproject.toml poetry.lock whisk-system.sh /home/nuvolaris/
 
 # prepares the required folders to deploy the whisk-system actions

--- a/deploy/nuvolaris-permissions/whisk-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-crd.yaml
@@ -248,7 +248,20 @@ spec:
                       type: integer
                     replicas:
                       description: number of total postgres replicas (1 primary, N-1 replicas). Defaulted to 2
-                      type: integer                      
+                      type: integer
+                    failover:
+                      description: enable or disable failover management. Defaulted to false
+                      type: boolean
+                    backup:
+                      description: controls postgres automatic backup using pgdump_app based script
+                      type: object
+                      properties:
+                        enabled:
+                          description: boolean flag enabling/disabling backup. Defaulted to false
+                          type: boolean
+                        schedule:
+                          description: cron based expression to control backup schedule. Default to once per hour at minute 30.
+                          type: string                          
                     admin:
                       description: postgres admin user credentials
                       type: object

--- a/deploy/postgres-backup/postgres-backup-conf.yaml
+++ b/deploy/postgres-backup/postgres-backup-conf.yaml
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: base-kubegres-backup-config
+  namespace: nuvolaris
+data:
+  backup_database.sh: |
+    #!/bin/bash
+    set -e
+
+    dt=$(date '+%d/%m/%Y %H:%M:%S');
+    fileDt=$(date '+%d_%m_%Y_%H_%M_%S');
+    backUpFileName="$KUBEGRES_RESOURCE_NAME-backup-$fileDt.gz"
+    backUpFilePath="$BACKUP_DESTINATION_FOLDER/$backUpFileName"
+
+    echo "$dt - Starting DB backup of Kubegres resource $KUBEGRES_RESOURCE_NAME into file: $backUpFilePath";
+    echo "$dt - Running: pg_dumpall -h $BACKUP_SOURCE_DB_HOST_NAME -U postgres -c | gzip > $backUpFilePath"
+
+    pg_dumpall -h $BACKUP_SOURCE_DB_HOST_NAME -U postgres -c | gzip > $backUpFilePath
+
+    if [ $? -ne 0 ]; then
+      rm $backUpFilePath
+      echo "Unable to execute a BackUp. Please check DB connection settings"
+      exit 1
+    fi
+
+    echo "$dt - DB backup completed for Kubegres resource $KUBEGRES_RESOURCE_NAME into file: $backUpFilePath";
+  backup_start.sh: |
+      #!/bin/bash
+      set -e
+      dt=$(date '+%d/%m/%Y %H:%M:%S');
+      set -m
+
+      # Start the helper processes
+      service rsyslog start
+      service cron start
+
+      echo "$dt - Scheduling: $BACKUP_SCHEDULE /tmp/backup_database.sh"
+      (crontab -l 2>/dev/null || true; echo "$BACKUP_SCHEDULE /tmp/backup_database.sh /dev/stdout 2>&1") | crontab -
+      while true; do sleep 60; done;
+

--- a/deploy/postgres-backup/postgres-backup-conf.yaml
+++ b/deploy/postgres-backup/postgres-backup-conf.yaml
@@ -42,6 +42,7 @@ data:
       exit 1
     fi
 
+    find $BACKUP_DESTINATION_FOLDER -type f -mtime +1 -name '*.gz' -execdir rm -- '{}' \;
     echo "$dt - DB backup completed for Kubegres resource $KUBEGRES_RESOURCE_NAME into file: $backUpFilePath";
   backup_start.sh: |
       #!/bin/bash
@@ -54,6 +55,6 @@ data:
       service cron start
 
       echo "$dt - Scheduling: $BACKUP_SCHEDULE /tmp/backup_database.sh"
-      (crontab -l 2>/dev/null || true; echo "$BACKUP_SCHEDULE /tmp/backup_database.sh /dev/stdout 2>&1") | crontab -
+      (crontab -l 2>/dev/null || true; echo "$BACKUP_SCHEDULE export KUBEGRES_RESOURCE_NAME=$KUBEGRES_RESOURCE_NAME; export BACKUP_DESTINATION_FOLDER=$BACKUP_DESTINATION_FOLDER; export BACKUP_SOURCE_DB_HOST_NAME=$BACKUP_SOURCE_DB_HOST_NAME; export PGPASSWORD=$PGPASSWORD; /tmp/backup_database.sh /dev/stdout 2>&1;") | crontab -
       while true; do sleep 60; done;
 

--- a/deploy/postgres-backup/postgres-backup-sts.yaml
+++ b/deploy/postgres-backup/postgres-backup-sts.yaml
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: nuvolaris-postgres-backup
+  namespace: nuvolaris
+spec:
+  serviceName: nuvolaris-postgres-backup
+  replicas: 1
+  selector:
+    matchLabels:
+      name: nuvolaris-postgres-backup   
+  template:
+    metadata:
+      labels:
+        name: nuvolaris-postgres-backup
+        app: nuvolaris-postgres-backup
+      annotations:
+        whisks.nuvolaris.org/annotate-version: "true"         
+    spec:
+      restartPolicy: Always    
+      containers:
+      - name: nuvolaris-postgres-backup
+        image: ghcr.io/nuvolaris/pg-dumper:14.1.2403192133
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash","-c","/root/backup_start.sh"]
+        env:
+        - name: BACKUP_SCHEDULE
+          value: "30 * * * *"
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: superUserPassword
+              name: postgres-nuvolaris-secret
+        - name: KUBEGRES_RESOURCE_NAME
+          value: nuvolaris-postgres
+        - name: BACKUP_DESTINATION_FOLDER
+          value: /var/lib/backup
+        - name: BACKUP_SOURCE_DB_HOST_NAME
+          value: nuvolaris-postgres-replica
+        - name: BACKUP_IMPORT_DB_HOST_NAME
+          value: nuvolaris-postgres
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: superUserPassword
+              name: postgres-nuvolaris-secret
+        - name: POSTGRES_REPLICATION_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: replicationUserPassword
+              name: postgres-nuvolaris-secret
+        - name: POSTGRES_NUVOLARIS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: nuvolarisUserPassword
+              name: postgres-nuvolaris-secret
+        volumeMounts:
+        - mountPath: /tmp/backup_database.sh
+          name: config
+          subPath: backup_database.sh
+        - mountPath: /root/backup_start.sh
+          name: config
+          subPath: backup_start.sh          
+      volumes:
+        - name: config
+          configMap:
+            name: base-kubegres-backup-config
+            defaultMode: 511
+            items:
+              - key: backup_database.sh
+                path: backup_database.sh
+              - key: backup_start.sh
+                path: backup_start.sh                

--- a/nuvolaris/templates/dep-attach.yaml
+++ b/nuvolaris/templates/dep-attach.yaml
@@ -15,23 +15,33 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-!kubectl -n nuvolaris delete kubegres --all
-!kubectl -n nuvolaris delete all --all
-!kubectl -n nuvolaris delete pvc --all
-
-import nuvolaris.config as cfg
-import nuvolaris.testutil as tu
-import nuvolaris.kube as kube
-import nuvolaris.postgres_operator as pdb
-import logging
-
-# test
-assert(cfg.configure(tu.load_sample_config()))
-cfg.detect_storage()
-assert(pdb.create())
-
-assert(kube.kubectl("get", f"cm/config", jsonpath="{.metadata.annotations.postgres_host}"))
-#assert(pdb.delete())
-
-#!kubectl -n nuvolaris delete all --all
-#!kubectl -n nuvolaris delete pvc --all
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{name}}
+  namespace: nuvolaris
+spec:
+  template:
+    spec:
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{name}}-pvc
+      containers:
+        - name: {{container}}
+          volumeMounts:
+            - name: {{name}}-pvc
+              mountPath: {{dir}}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{name}}-pvc
+    spec:
+      accessModes:
+        - 'ReadWriteOnce'
+      resources:
+        requests:
+          storage: {{size}}Gi
+      storageClassName: {{storageClass}}
+{% if hostpath %}
+      volumeName: {{name}}-pv
+{% endif %}

--- a/nuvolaris/templates/postgres-backup-sts.yaml
+++ b/nuvolaris/templates/postgres-backup-sts.yaml
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: nuvolaris-postgres-backup
+  namespace: nuvolaris
+spec:
+  serviceName: nuvolaris-postgres-backup
+  replicas: 1
+  selector:
+    matchLabels:
+      name: nuvolaris-postgres-backup   
+  template:
+    metadata:
+      labels:
+        name: nuvolaris-postgres-backup
+        app: nuvolaris-postgres-backup
+      annotations:
+        whisks.nuvolaris.org/annotate-version: "true"         
+    spec:
+      restartPolicy: Always    
+      containers:
+      - name: nuvolaris-postgres-backup
+        image: ghcr.io/nuvolaris/pg-dumper:14.1.2403192133
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash","-c","/root/backup_start.sh"]
+        env:
+        - name: BACKUP_SCHEDULE
+          value: "{{schedule}}"
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: superUserPassword
+              name: postgres-nuvolaris-secret
+        - name: KUBEGRES_RESOURCE_NAME
+          value: nuvolaris-postgres
+        - name: BACKUP_DESTINATION_FOLDER
+          value: {{dir}}
+        - name: BACKUP_SOURCE_DB_HOST_NAME
+          value: nuvolaris-postgres-replica
+        - name: BACKUP_IMPORT_DB_HOST_NAME
+          value: nuvolaris-postgres
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: superUserPassword
+              name: postgres-nuvolaris-secret
+        - name: POSTGRES_REPLICATION_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: replicationUserPassword
+              name: postgres-nuvolaris-secret
+        - name: POSTGRES_NUVOLARIS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: nuvolarisUserPassword
+              name: postgres-nuvolaris-secret
+        volumeMounts:
+        - mountPath: /tmp/backup_database.sh
+          name: config
+          subPath: backup_database.sh
+        - mountPath: /root/backup_start.sh
+          name: config
+          subPath: backup_start.sh          
+      volumes:
+        - name: config
+          configMap:
+            name: base-kubegres-backup-config
+            defaultMode: 511
+            items:
+              - key: backup_database.sh
+                path: backup_database.sh
+              - key: backup_start.sh
+                path: backup_start.sh

--- a/nuvolaris/templates/postgres.yaml
+++ b/nuvolaris/templates/postgres.yaml
@@ -28,6 +28,8 @@ spec:
       size: {{size}}Gi
       storageClassName: {{storageClass}}
    customConfig: nuvolaris-postgres-conf
+   failover:
+    isDisabled: {{not failover}}
    scheduler:
       affinity:
       {% if affinity %}

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -367,7 +367,22 @@ def get_postgres_config_data():
         'postgres_nuvolaris_password': cfg.get('postgres.nuvolaris.password') or "s0meP@ass3",
         'size': cfg.get('postgres.volume-size') or 10,
         'replicas': cfg.get('postgres.admin.replicas') or 2,
-        'storageClass': cfg.get('nuvolaris.storageclass')
+        'storageClass': cfg.get('nuvolaris.storageclass'),
+        'failover': cfg.get('postgres.failover') or False,
+        'backup': cfg.get('postgres.backup.enabled') or False,
+        'schedule': cfg.get('postgres.backup.schedule') or '30 * * * *'
+        }
+    postgres_affinity_tolerations_data(data)
+    return data
+
+def get_postgres_backup_data():
+    data = {
+        'size': cfg.get('postgres.volume-size') or 10,
+        'storageClass': cfg.get('nuvolaris.storageclass'),
+        'schedule': cfg.get('postgres.backup.schedule') or '30 * * * *',
+        'name': 'nuvolaris-postgres-backup',
+        'dir':'/var/lib/backup',
+        'container':'nuvolaris-postgres-backup'
         }
     postgres_affinity_tolerations_data(data)
     return data
@@ -485,6 +500,10 @@ def postgres_manager_affinity_tolerations_data():
     }
     common_affinity_tolerations_data(data)
     return data
+
+def postgres_backup_affinity_tolerations_data(data):
+    common_affinity_tolerations_data(data)
+    data["pod_anti_affinity_name"] = "nuvolaris-postgres-backup" 
                       
 
     

--- a/tests/kind/postgres_op_test.ipy
+++ b/tests/kind/postgres_op_test.ipy
@@ -31,7 +31,7 @@ cfg.detect_storage()
 assert(pdb.create())
 
 assert(kube.kubectl("get", f"cm/config", jsonpath="{.metadata.annotations.postgres_host}"))
-#assert(pdb.delete())
+assert(pdb.delete())
 
-#!kubectl -n nuvolaris delete all --all
-#!kubectl -n nuvolaris delete pvc --all
+!kubectl -n nuvolaris delete all --all
+!kubectl -n nuvolaris delete pvc --all

--- a/tests/kind/whisk.yaml
+++ b/tests/kind/whisk.yaml
@@ -132,4 +132,7 @@ spec:
       password: 0therPa55
       replica-password: 0therPa55RR
     nuvolaris:
-      password: s0meP@ass3                   
+      password: s0meP@ass3
+    backup:
+      enabled: true 
+      schedule: "30 * * * *"                        

--- a/tests/whisk.yaml
+++ b/tests/whisk.yaml
@@ -114,3 +114,6 @@ spec:
       replicas-password: 0therPa55RR
     nuvolaris:
       password: s0meP@ass3
+    backup:
+      enabled: true 
+      schedule: "*/2 * * * *"

--- a/tests/whisk.yaml
+++ b/tests/whisk.yaml
@@ -115,5 +115,5 @@ spec:
     nuvolaris:
       password: s0meP@ass3
     backup:
-      enabled: true 
+      enabled: false 
       schedule: "*/2 * * * *"


### PR DESCRIPTION
This PR adds to community operator the support to enable/disable kubegres failover and backup, by handling extra parameters inside the whisk.crd.

Both failover and backup are disabled by default.

```
                postgres:
                  description: used to configure a nuvolaris shared postgres instance
                  type: object
                  properties:
                    volume-size:
                      description: postgres volume size in GB
                      type: integer
                    replicas:
                      description: number of total postgres replicas (1 primary, N-1 replicas). Defaulted to 2
                      type: integer
                    failover:
                      description: enable or disable failover management. Defaulted to false
                      type: boolean
                    backup:
                      description: controls postgres automatic backup using pgdump_app based script
                      type: object
                      properties:
                        enabled:
                          description: boolean flag enabling/disabling backup. Defaulted to false
                          type: boolean
                        schedule:
                          description: cron based expression to control backup schedule. Default to once per hour at minute 30.
                          type: string 
```

In case the backup it is activated the operator will deploy a new STS and corresponding PVC where all the generated backups will be dumped. The StatefulSet controls a pod which is continuously running and executed the backup using a crontab script. Doing so velcro will include automatically the PV into the backup and therefore it will be restored in case it is needed. The backup script removes the backup older than 7 days, to minimise the space used on the PV. They will be normally present in older backups.