### PR TITLE
Partially implements nuvolaris/projects#98

### DIFF
--- a/deploy/couchdb/couchdb-svc.yaml
+++ b/deploy/couchdb/couchdb-svc.yaml
@@ -24,7 +24,8 @@ metadata:
 spec:
   type: NodePort
   selector:
-    name: couchdb
+    app: nuvolaris-couchdb        
+    replicationRole: primary
   ports:   
     - port: 5984
       targetPort: 5984
@@ -37,7 +38,8 @@ metadata:
   namespace: nuvolaris
 spec:
   selector:
-    name: couchdb
+    app: nuvolaris-couchdb        
+    replicationRole: primary
   ports:   
     - port: 5984
       targetPort: 5984

--- a/nuvolaris/couchdb.py
+++ b/nuvolaris/couchdb.py
@@ -63,7 +63,10 @@ def create(owner=None):
         "container_cpu_lim": cfg.get('configs.couchdb.resources.cpu-lim') or "1",
         "container_mem_req": cfg.get('configs.couchdb.resources.mem-req') or "1G",
         "container_mem_lim": cfg.get('configs.couchdb.resources.mem-lim') or "2G",
-        "container_manage_resources": cfg.exists('configs.couchdb.resources.cpu-req')    
+        "container_manage_resources": cfg.exists('configs.couchdb.resources.cpu-req'),
+        "index": "1",
+        "replicationRole":"primary",
+        "appName":"nuvolaris-couchdb"
     }
 
     tplp = ["set-attach.yaml"]

--- a/nuvolaris/templates/couchdb-set-tpl.yaml
+++ b/nuvolaris/templates/couchdb-set-tpl.yaml
@@ -19,18 +19,28 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: couchdb
   namespace: nuvolaris
+  name: {{name}}
+  labels:
+    name: {{name}} 
+    app: {{appName}}
+    index: "{{index}}"
+    replicationRole: "{{replicationRole}}"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: couchdb
-  serviceName: couchdb
+      name: {{name}}
+      app: {{appName}}
+      index: "{{index}}"
+  serviceName: {{name}}
   template:
     metadata:
       labels:
-        name: couchdb
+        name: {{name}}
+        app: {{appName}}
+        index: "{{index}}" 
+        replicationRole: primary
       annotations:
         whisks.nuvolaris.org/annotate-version: "true"  
     spec:


### PR DESCRIPTION
This PR adds  following configurations to couchdb deployment

- adds extra labels, app: nuvolaris-couchdb replicationRole: primary
- configure the couchdb and couchdb-np services to match the labels  app: nuvolaris-couchdb replicationRole: primary