### PR TITLE
fix: ensuring postgres config locate primary related resources

### DIFF
--- a/nuvolaris/postgres_operator.py
+++ b/nuvolaris/postgres_operator.py
@@ -95,7 +95,8 @@ def create(owner=None):
 def update_system_cm_for_pdb(data):
     logging.info("*** annotating configuration for postgres nuvolaris user")
     try:        
-        pdb_service = util.get_service("{.items[?(@.metadata.labels.replicationRole == 'primary')]}")
+        pdb_service = util.get_service_by_selector("app=nuvolaris-postgres","{.items[?(@.metadata.labels.replicationRole == 'primary')]}")
+        
         if(pdb_service):             
             pdb_service_name = pdb_service['metadata']['name']
             pdb_ns = pdb_service['metadata']['namespace']
@@ -120,7 +121,8 @@ def update_system_cm_for_pdb(data):
 
 def get_base_postgres_url(data):    
     try:        
-        pdb_service = util.get_service("{.items[?(@.metadata.labels.replicationRole == 'primary')]}")
+        pdb_service = util.get_service_by_selector("app=nuvolaris-postgres","{.items[?(@.metadata.labels.replicationRole == 'primary')]}")
+
         if(pdb_service):             
             pdb_service_name = pdb_service['metadata']['name']
             pdb_ns = pdb_service['metadata']['namespace']
@@ -141,7 +143,7 @@ def _add_pdb_user_metadata(ucfg, user_metadata):
     """ 
 
     try:
-        pdb_service = util.get_service("{.items[?(@.metadata.labels.replicationRole == 'primary')]}")
+        pdb_service = util.get_service_by_selector("app=nuvolaris-postgres","{.items[?(@.metadata.labels.replicationRole == 'primary')]}")
 
         if(pdb_service):
             pdb_service_name = pdb_service['metadata']['name']
@@ -195,7 +197,7 @@ def create_db_user(ucfg: UserConfig, user_metadata: UserMetadata):
 
         path_to_pgpass = render_postgres_script(ucfg.get('namespace'),"pgpass_tpl.properties",data)
         path_to_mdb_script = render_postgres_script(ucfg.get('namespace'),"postgres_manage_user_tpl.sql",data)
-        pod_name = util.get_pod_name("{.items[?(@.metadata.labels.app == 'nuvolaris-postgres')].metadata.name}")
+        pod_name = util.get_pod_name_by_selector("app=nuvolaris-postgres","{.items[?(@.metadata.labels.replicationRole == 'primary')].metadata.name}")
 
         if(pod_name):
             res = exec_psql_command(pod_name,path_to_mdb_script,path_to_pgpass)
@@ -222,7 +224,7 @@ def delete_db_user(namespace, database):
 
         path_to_pgpass = render_postgres_script(namespace,"pgpass_tpl.properties",data)
         path_to_mdb_script = render_postgres_script(namespace,"postgres_manage_user_tpl.sql",data)
-        pod_name = util.get_pod_name("{.items[?(@.metadata.labels.app == 'nuvolaris-postgres')].metadata.name}")
+        pod_name = util.get_pod_name_by_selector("app=nuvolaris-postgres","{.items[?(@.metadata.labels.replicationRole == 'primary')].metadata.name}")
 
         if(pod_name):
             res = exec_psql_command(pod_name,path_to_mdb_script,path_to_pgpass)

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -503,7 +503,38 @@ def postgres_manager_affinity_tolerations_data():
 
 def postgres_backup_affinity_tolerations_data(data):
     common_affinity_tolerations_data(data)
-    data["pod_anti_affinity_name"] = "nuvolaris-postgres-backup" 
+    data["pod_anti_affinity_name"] = "nuvolaris-postgres-backup"
+
+# wait for a pod name using a label selector and eventually an optional jsonpath
+@nuv_retry()
+def get_pod_name_by_selector(selector, jsonpath, namespace="nuvolaris"):
+    """
+    get pods matching the given selector filtering them using the given jsonpath.
+    param: selector (eg app="nuvolaris-postgres")
+    param: jsonpath (eg "{.items[?(@.metadata.labels.replicationRole == 'primary')].metadata.name}")
+    return: 1st mathing pod name
+    """
+    pod_names = kube.kubectl("get", "pods","-l", selector, namespace=namespace, jsonpath=jsonpath)
+    if(pod_names):
+        return pod_names[0]
+
+    raise Exception(f"could not find any pod matching jsonpath={jsonpath}")
+
+# wait for a svc name using a label selector and eventually an optional jsonpath
+@nuv_retry()
+def get_service_by_selector(selector,jsonpath,namespace="nuvolaris"):
+    """
+    get services matching the given selector filtering them using the given jsonpath
+    param: selector (eg app="nuvolaris-postgres")
+    param: jsonpath (eg "{.items[?(@.metadata.labels.replicationRole == 'primary')].metadata.name}")
+    return: 1st mathing service name
+    """
+    services= kube.kubectl("get", "svc","-l",selector, namespace=namespace, jsonpath=jsonpath)
+    if(services):
+        return services[0]
+
+    raise Exception(f"could not find any svc matching jsonpath={jsonpath}")
+
                       
 
     


### PR DESCRIPTION
This PR ensure that configuration of postgres related resources is executed properly locating postgres and service with replicationRole=primary